### PR TITLE
Language Support Testing

### DIFF
--- a/actions/ci.bash
+++ b/actions/ci.bash
@@ -1,5 +1,5 @@
 bt() {
-    bazel test --verbose_failures "$@" //py/...
+    bazel test --verbose_failures "$@" //py/... //cpp/... //languagesupport/...
     RESULT=$?
     if [ $RESULT -ne 0 ] ; then
         echo " "

--- a/actions/format.bash
+++ b/actions/format.bash
@@ -15,10 +15,10 @@ echo "black"
 black $DEFAULT ;
 
 echo "isort"
-isort --profile black py/ featuretests/;
+isort --profile black py/ featuretests/ languagesupport/
 
 echo "codespell"
-codespell py/ featuretests/
+codespell py/ featuretests/ languagesupport/
 
 echo "clang-format"
 SEARCHRESULT=$(ag --cpp -g ".*" $DEFAULT) ;

--- a/actions/test.bash
+++ b/actions/test.bash
@@ -1,5 +1,5 @@
 bt() {
-    bazel test --verbose_failures "$@" //py/...
+    bazel test --verbose_failures "$@" //py/... //cpp/... //languagesupport/...
     RESULT=$?
     if [ $RESULT -ne 0 ] ; then
         echo " "

--- a/docs/formak/language_support.md
+++ b/docs/formak/language_support.md
@@ -1,0 +1,7 @@
+# Language Support
+
+## C++ 17
+
+FormaK has tests ( `//languagesupport/...` ) to continually verify that the
+configuration via Bazel continues to support C++ 17. When updating bazel, make
+sure to run the language support tests.

--- a/languagesupport/cpp/BUILD
+++ b/languagesupport/cpp/BUILD
@@ -11,3 +11,9 @@ cc_test(
     srcs = ["cpp14.cpp"],
     deps = CC_FEATURE_TEST_DEPS,
 )
+
+cc_test(
+    name = "cpp17",
+    srcs = ["cpp17.cpp"],
+    deps = CC_FEATURE_TEST_DEPS,
+)

--- a/languagesupport/cpp/BUILD
+++ b/languagesupport/cpp/BUILD
@@ -1,0 +1,7 @@
+load("//featuretests:test_deps.bzl", "CC_FEATURE_TEST_DEPS")
+
+cc_test(
+    name = "cpp11",
+    srcs = ["cpp11.cpp"],
+    deps = CC_FEATURE_TEST_DEPS,
+)

--- a/languagesupport/cpp/BUILD
+++ b/languagesupport/cpp/BUILD
@@ -5,3 +5,9 @@ cc_test(
     srcs = ["cpp11.cpp"],
     deps = CC_FEATURE_TEST_DEPS,
 )
+
+cc_test(
+    name = "cpp14",
+    srcs = ["cpp14.cpp"],
+    deps = CC_FEATURE_TEST_DEPS,
+)

--- a/languagesupport/cpp/cpp11.cpp
+++ b/languagesupport/cpp/cpp11.cpp
@@ -1,0 +1,14 @@
+#include <gtest/gtest.h>
+
+namespace languagesupport {
+namespace cpp11 {
+
+TEST(Cpp11, AutoAndIsSame) {
+  int i = 0;
+  auto a = i;
+  static_assert(std::is_same_v<decltype(a), int> == true);
+  EXPECT_EQ(a, 0);
+}
+
+}  // namespace cpp11
+}  // namespace languagesupport

--- a/languagesupport/cpp/cpp14.cpp
+++ b/languagesupport/cpp/cpp14.cpp
@@ -1,0 +1,13 @@
+#include <gtest/gtest.h>
+
+#include <memory>
+
+namespace featuresupport {
+namespace cpp14 {
+TEST(Cpp14, MakeUnique) {
+  std::unique_ptr<int> i = std::make_unique<int>(4);
+
+  EXPECT_EQ(*i, 4);
+}
+}  // namespace cpp14
+}  // namespace featuresupport

--- a/languagesupport/cpp/cpp17.cpp
+++ b/languagesupport/cpp/cpp17.cpp
@@ -1,0 +1,15 @@
+#include <gtest/gtest.h>
+
+#include <memory>
+
+namespace featuresupport {
+namespace cpp17 {
+TEST(Cpp17, IfConstexpr) {
+  if constexpr (true) {
+    SUCCEED();
+  } else {
+    FAIL();
+  }
+}
+}  // namespace cpp17
+}  // namespace featuresupport


### PR DESCRIPTION
FormaK lists its language feature support as C++17.

These tests will ensure that the configuration remains correct to support C++17 (and eventually other language configuration, e.g. Python version).