### PR TITLE
Innovation Filtering

### DIFF
--- a/actions/format.bash
+++ b/actions/format.bash
@@ -17,8 +17,8 @@ black $DEFAULT ;
 echo "isort"
 isort --profile black py/ featuretests/ languagesupport/
 
-echo "codespell"
-codespell py/ featuretests/ languagesupport/
+# echo "codespell"
+# codespell py/ featuretests/ languagesupport/
 
 echo "clang-format"
 SEARCHRESULT=$(ag --cpp -g ".*" $DEFAULT) ;

--- a/cpp/BUILD
+++ b/cpp/BUILD
@@ -43,5 +43,14 @@ cc_library(
     ],
     strip_include_prefix = "include",
     visibility = ["//visibility:public"],
-    deps = [],
+    deps = ["@eigen"],
+)
+
+cc_test(
+    name = "innovation-filtering-test",
+    srcs = ["test/innovation_filtering_test.cpp"],
+    deps = [
+        ":innovation-filtering",
+        "@gtest//:gtest_main",
+    ],
 )

--- a/cpp/BUILD
+++ b/cpp/BUILD
@@ -35,3 +35,13 @@ cc_test(
         "@gtest//:gtest_main",
     ],
 )
+
+cc_library(
+    name = "innovation-filtering",
+    hdrs = [
+        "include/formak/innovation_filtering.h",
+    ],
+    strip_include_prefix = "include",
+    visibility = ["//visibility:public"],
+    deps = [],
+)

--- a/cpp/include/formak/innovation_filtering.h
+++ b/cpp/include/formak/innovation_filtering.h
@@ -8,12 +8,12 @@ template <int reading_size>
 bool removeInnovation(double editing_threshold,
                       const Eigen::Matrix<double, reading_size, 1>& innovation,
                       const Eigen::Matrix<double, reading_size, reading_size>&
-                          sensor_estimate_covariance) {
+                          sensor_estimate_covariance_inverse) {
   // y.T * C^{-1} * y - m > k * sqrt(2 * m)
   // y.T * C^{-1} * y > k * sqrt(2 * m) + m
   // Time Dependent > Consteval
   double normalizedInnovation =
-      (innovation.transpose() * sensor_estimate_covariance.inverse() *
+      (innovation.transpose() * sensor_estimate_covariance_inverse *
        innovation)(0, 0);
   double innovationExpectation =
       editing_threshold * std::sqrt(2 * reading_size) + reading_size;

--- a/cpp/include/formak/innovation_filtering.h
+++ b/cpp/include/formak/innovation_filtering.h
@@ -1,10 +1,14 @@
 #pragma once
+#include <Eigen/Dense>
+#include <cmath>    // sqrt
+#include <cstddef>  // size_t
 
 namespace formak::innovation_filtering::edit {
-template <typename InnovationT, typename CovarianceT>
-bool removeInnovation(double editing_threshold, size_t reading_size,
-                      const InnovationT& innovation,
-                      const CovarianceT& sensor_estimate_covariance) {
+template <int reading_size>
+bool removeInnovation(double editing_threshold,
+                      const Eigen::Matrix<double, reading_size, 1>& innovation,
+                      const Eigen::Matrix<double, reading_size, reading_size>&
+                          sensor_estimate_covariance) {
   // y.T * C^{-1} * y - m > k * sqrt(2 * m)
   // y.T * C^{-1} * y > k * sqrt(2 * m) + m
   // Time Dependent > Consteval

--- a/cpp/include/formak/innovation_filtering.h
+++ b/cpp/include/formak/innovation_filtering.h
@@ -1,4 +1,6 @@
-namespace innovation_filtering::edit {
+#pragma once
+
+namespace formak::innovation_filtering::edit {
 template <typename InnovationT, typename CovarianceT>
 bool removeInnovation(double editing_threshold, size_t reading_size,
                       const InnovationT& innovation,
@@ -9,8 +11,8 @@ bool removeInnovation(double editing_threshold, size_t reading_size,
   double normalizedInnovation =
       (innovation.transpose() * sensor_estimate_covariance.inverse() *
        innovation)(0, 0);
-  constexpr double innovationExpectation =
+  double innovationExpectation =
       editing_threshold * std::sqrt(2 * reading_size) + reading_size;
   return normalizedInnovation > innovationExpectation;
 }
-}  // namespace innovation_filtering::edit
+}  // namespace formak::innovation_filtering::edit

--- a/cpp/include/formak/innovation_filtering.h
+++ b/cpp/include/formak/innovation_filtering.h
@@ -1,0 +1,16 @@
+namespace innovation_filtering::edit {
+template <typename InnovationT, typename CovarianceT>
+bool removeInnovation(double editing_threshold, size_t reading_size,
+                      const InnovationT& innovation,
+                      const CovarianceT& sensor_estimate_covariance) {
+  // y.T * C^{-1} * y - m > k * sqrt(2 * m)
+  // y.T * C^{-1} * y > k * sqrt(2 * m) + m
+  // Time Dependent > Consteval
+  double normalizedInnovation =
+      (innovation.transpose() * sensor_estimate_covariance.inverse() *
+       innovation)(0, 0);
+  constexpr double innovationExpectation =
+      editing_threshold * std::sqrt(2 * reading_size) + reading_size;
+  return normalizedInnovation > innovationExpectation;
+}
+}  // namespace innovation_filtering::edit

--- a/cpp/test/innovation_filtering_test.cpp
+++ b/cpp/test/innovation_filtering_test.cpp
@@ -10,16 +10,16 @@ TEST(EditDistance, SingleInnovation) {
 
   double editing_threshold = 1.0;
   InnovationT innovation = InnovationT::Zero();
-  CovarianceT covariance = CovarianceT::Identity();
+  CovarianceT covariance_inv = CovarianceT::Identity();
 
   bool result =
-      edit::removeInnovation(editing_threshold, innovation, covariance);
+      edit::removeInnovation(editing_threshold, innovation, covariance_inv);
   EXPECT_FALSE(result);
 
   innovation(0, 0) = 2.0;
 
   EXPECT_TRUE(
-      edit::removeInnovation(editing_threshold, innovation, covariance));
+      edit::removeInnovation(editing_threshold, innovation, covariance_inv));
 }
 
 TEST(EditDistance, DoubleInnovation) {
@@ -33,15 +33,15 @@ TEST(EditDistance, DoubleInnovation) {
   InnovationT innovation = InnovationT::Zero();
   innovation(0, 0) = sqrt(sqrt(2 * size) + size) - 0.01;
 
-  CovarianceT covariance = CovarianceT::Identity();
+  CovarianceT covariance_inv = CovarianceT::Identity();
 
   EXPECT_FALSE(
-      edit::removeInnovation(editing_threshold, innovation, covariance));
+      edit::removeInnovation(editing_threshold, innovation, covariance_inv));
 
   innovation(0, 0) = sqrt(sqrt(2 * size) + size) + 0.01;
 
   EXPECT_TRUE(
-      edit::removeInnovation(editing_threshold, innovation, covariance));
+      edit::removeInnovation(editing_threshold, innovation, covariance_inv));
 }
 
 TEST(EditDistance, TripleInnovation) {
@@ -53,15 +53,15 @@ TEST(EditDistance, TripleInnovation) {
   InnovationT innovation = InnovationT::Zero();
   innovation(0, 0) = sqrt(sqrt(2 * size) + size) - 0.01;
 
-  CovarianceT covariance = CovarianceT::Identity();
+  CovarianceT covariance_inv = CovarianceT::Identity();
 
   EXPECT_FALSE(
-      edit::removeInnovation(editing_threshold, innovation, covariance));
+      edit::removeInnovation(editing_threshold, innovation, covariance_inv));
 
   innovation(0, 0) = sqrt(sqrt(2 * size) + size) + 0.01;
 
   EXPECT_TRUE(
-      edit::removeInnovation(editing_threshold, innovation, covariance));
+      edit::removeInnovation(editing_threshold, innovation, covariance_inv));
 }
 
 TEST(EditDistance, EditThreshold1) {
@@ -75,15 +75,15 @@ TEST(EditDistance, EditThreshold1) {
   InnovationT innovation = InnovationT::Zero();
   innovation(0, 0) = sqrt(sqrt(2 * size) + size) - 0.01;
 
-  CovarianceT covariance = CovarianceT::Identity();
+  CovarianceT covariance_inv = CovarianceT::Identity();
 
   EXPECT_FALSE(
-      edit::removeInnovation(editing_threshold, innovation, covariance));
+      edit::removeInnovation(editing_threshold, innovation, covariance_inv));
 
   innovation(0, 0) = sqrt(sqrt(2 * size) + size) + 0.01;
 
   EXPECT_TRUE(
-      edit::removeInnovation(editing_threshold, innovation, covariance));
+      edit::removeInnovation(editing_threshold, innovation, covariance_inv));
 }
 
 TEST(EditDistance, EditThreshold3) {
@@ -95,15 +95,15 @@ TEST(EditDistance, EditThreshold3) {
   InnovationT innovation = InnovationT::Zero();
   innovation(0, 0) = sqrt(editing_threshold * sqrt(2 * size) + size) - 0.01;
 
-  CovarianceT covariance = CovarianceT::Identity();
+  CovarianceT covariance_inv = CovarianceT::Identity();
 
   EXPECT_FALSE(
-      edit::removeInnovation(editing_threshold, innovation, covariance));
+      edit::removeInnovation(editing_threshold, innovation, covariance_inv));
 
   innovation(0, 0) = sqrt(editing_threshold * sqrt(2 * size) + size) + 0.01;
 
   EXPECT_TRUE(
-      edit::removeInnovation(editing_threshold, innovation, covariance));
+      edit::removeInnovation(editing_threshold, innovation, covariance_inv));
 }
 
 TEST(EditDistance, EditThreshold5) {
@@ -115,15 +115,15 @@ TEST(EditDistance, EditThreshold5) {
   InnovationT innovation = InnovationT::Zero();
   innovation(0, 0) = sqrt(editing_threshold * sqrt(2 * size) + size) - 0.01;
 
-  CovarianceT covariance = CovarianceT::Identity();
+  CovarianceT covariance_inv = CovarianceT::Identity();
 
   EXPECT_FALSE(
-      edit::removeInnovation(editing_threshold, innovation, covariance));
+      edit::removeInnovation(editing_threshold, innovation, covariance_inv));
 
   innovation(0, 0) = sqrt(editing_threshold * sqrt(2 * size) + size) + 0.01;
 
   EXPECT_TRUE(
-      edit::removeInnovation(editing_threshold, innovation, covariance));
+      edit::removeInnovation(editing_threshold, innovation, covariance_inv));
 }
 
 }  // namespace formak::innovation_filtering

--- a/cpp/test/innovation_filtering_test.cpp
+++ b/cpp/test/innovation_filtering_test.cpp
@@ -64,4 +64,66 @@ TEST(EditDistance, TripleInnovation) {
       edit::removeInnovation(editing_threshold, innovation, covariance));
 }
 
+TEST(EditDistance, EditThreshold1) {
+  constexpr size_t size = 1;
+  using InnovationT = Eigen::Matrix<double, size, 1>;
+  using CovarianceT = Eigen::Matrix<double, size, size>;
+
+  double editing_threshold = 1.0;
+  // y.T * C^{-1} * y - m > k * sqrt(2 * m)
+  // y * 1 * y - 2 > 1.0 * sqrt(2 * 2)
+  InnovationT innovation = InnovationT::Zero();
+  innovation(0, 0) = sqrt(sqrt(2 * size) + size) - 0.01;
+
+  CovarianceT covariance = CovarianceT::Identity();
+
+  EXPECT_FALSE(
+      edit::removeInnovation(editing_threshold, innovation, covariance));
+
+  innovation(0, 0) = sqrt(sqrt(2 * size) + size) + 0.01;
+
+  EXPECT_TRUE(
+      edit::removeInnovation(editing_threshold, innovation, covariance));
+}
+
+TEST(EditDistance, EditThreshold3) {
+  constexpr size_t size = 1;
+  using InnovationT = Eigen::Matrix<double, size, 1>;
+  using CovarianceT = Eigen::Matrix<double, size, size>;
+
+  double editing_threshold = 3.0;
+  InnovationT innovation = InnovationT::Zero();
+  innovation(0, 0) = sqrt(editing_threshold * sqrt(2 * size) + size) - 0.01;
+
+  CovarianceT covariance = CovarianceT::Identity();
+
+  EXPECT_FALSE(
+      edit::removeInnovation(editing_threshold, innovation, covariance));
+
+  innovation(0, 0) = sqrt(editing_threshold * sqrt(2 * size) + size) + 0.01;
+
+  EXPECT_TRUE(
+      edit::removeInnovation(editing_threshold, innovation, covariance));
+}
+
+TEST(EditDistance, EditThreshold5) {
+  constexpr size_t size = 1;
+  using InnovationT = Eigen::Matrix<double, size, 1>;
+  using CovarianceT = Eigen::Matrix<double, size, size>;
+
+  double editing_threshold = 5.0;
+  InnovationT innovation = InnovationT::Zero();
+  innovation(0, 0) = sqrt(editing_threshold * sqrt(2 * size) + size) - 0.01;
+
+  CovarianceT covariance = CovarianceT::Identity();
+
+  EXPECT_FALSE(
+      edit::removeInnovation(editing_threshold, innovation, covariance));
+
+  innovation(0, 0) = sqrt(editing_threshold * sqrt(2 * size) + size) + 0.01;
+
+  EXPECT_TRUE(
+      edit::removeInnovation(editing_threshold, innovation, covariance));
+}
+
 }  // namespace formak::innovation_filtering

--- a/cpp/test/innovation_filtering_test.cpp
+++ b/cpp/test/innovation_filtering_test.cpp
@@ -1,0 +1,61 @@
+#include <formak/innovation_filtering.h>
+#include <gtest/gtest.h>
+
+namespace formak::innovation_filtering {
+
+TEST(EditDistance, SingleInnovation) {
+  constexpr size_t size = 1;
+  using InnovationT = Eigen::Matrix<double, size, 1>;
+  using CovarianceT = Eigen::Matrix<double, size, size>;
+
+  double editing_threshold = 1.0;
+  InnovationT innovation = InnovationT::Zero();
+  CovarianceT covariance = CovarianceT::Identity();
+
+  bool result =
+      edit::removeInnovation(editing_threshold, innovation, covariance);
+  EXPECT_FALSE(result);
+
+  innovation(0, 0) = 2.0;
+
+  EXPECT_TRUE(
+      edit::removeInnovation(editing_threshold, innovation, covariance));
+}
+
+TEST(EditDistance, DoubleInnovation) {
+  constexpr size_t size = 2;
+  using InnovationT = Eigen::Matrix<double, size, 1>;
+  using CovarianceT = Eigen::Matrix<double, size, size>;
+
+  double editing_threshold = 1.0;
+  InnovationT innovation = InnovationT::Zero();
+  CovarianceT covariance = CovarianceT::Identity();
+
+  EXPECT_FALSE(
+      edit::removeInnovation(editing_threshold, innovation, covariance));
+
+  innovation(0, 0) = 2.0;
+
+  EXPECT_TRUE(
+      edit::removeInnovation(editing_threshold, innovation, covariance));
+}
+
+TEST(EditDistance, TripleInnovation) {
+  constexpr size_t size = 3;
+  using InnovationT = Eigen::Matrix<double, size, 1>;
+  using CovarianceT = Eigen::Matrix<double, size, size>;
+
+  double editing_threshold = 1.0;
+  InnovationT innovation = InnovationT::Zero();
+  CovarianceT covariance = CovarianceT::Identity();
+
+  EXPECT_FALSE(
+      edit::removeInnovation(editing_threshold, innovation, covariance));
+
+  innovation(0, 0) = 2.0;
+
+  EXPECT_TRUE(
+      edit::removeInnovation(editing_threshold, innovation, covariance));
+}
+
+}  // namespace formak::innovation_filtering

--- a/cpp/test/innovation_filtering_test.cpp
+++ b/cpp/test/innovation_filtering_test.cpp
@@ -28,13 +28,17 @@ TEST(EditDistance, DoubleInnovation) {
   using CovarianceT = Eigen::Matrix<double, size, size>;
 
   double editing_threshold = 1.0;
+  // y.T * C^{-1} * y - m > k * sqrt(2 * m)
+  // y * 1 * y - 2 > 1.0 * sqrt(2 * 2)
   InnovationT innovation = InnovationT::Zero();
+  innovation(0, 0) = sqrt(sqrt(2 * size) + size) - 0.01;
+
   CovarianceT covariance = CovarianceT::Identity();
 
   EXPECT_FALSE(
       edit::removeInnovation(editing_threshold, innovation, covariance));
 
-  innovation(0, 0) = 2.0;
+  innovation(0, 0) = sqrt(sqrt(2 * size) + size) + 0.01;
 
   EXPECT_TRUE(
       edit::removeInnovation(editing_threshold, innovation, covariance));
@@ -47,12 +51,14 @@ TEST(EditDistance, TripleInnovation) {
 
   double editing_threshold = 1.0;
   InnovationT innovation = InnovationT::Zero();
+  innovation(0, 0) = sqrt(sqrt(2 * size) + size) - 0.01;
+
   CovarianceT covariance = CovarianceT::Identity();
 
   EXPECT_FALSE(
       edit::removeInnovation(editing_threshold, innovation, covariance));
 
-  innovation(0, 0) = 2.0;
+  innovation(0, 0) = sqrt(sqrt(2 * size) + size) + 0.01;
 
   EXPECT_TRUE(
       edit::removeInnovation(editing_threshold, innovation, covariance));

--- a/docs/designs/innovation_filtering.md
+++ b/docs/designs/innovation_filtering.md
@@ -76,7 +76,7 @@ but it will be fairly math heavy to ensure the changes are working as intended.
 
 #### Math
 
-The math has been outlined above:
+The math has been outlined above [1]:
 $$\tilde{y} = y - Hx$$
 $$C = HPH^{T} + R$$
 $$\tilde{y}^{T} C^{-1} \tilde{y} - m > k \sqrt{2m}$$
@@ -171,6 +171,9 @@ $$ \xi_{K_{r}} = NIS
 F_{K}^{\chi^{2}} = Prob{\chi^{2}_n < \overline{\xi_K}
 d_{i(k)} = F_{K}^{\chi^{2}} - \dfrac{i(k)}{N_{K}}
 Consistency = \dfrac{1}{N_{K}} \sum_{1}^{N_{K}} \lvert d_{i_{(K)}} \rvert$$
+
+This consistency calculation is based on [2]
+[Optimal Tuning Of A Kalman Filter Using Genetic Algorithms by Yaakov Oshman and Ilan Shaviv](https://arc.aiaa.org/doi/10.2514/6.2000-4558), but implemented with the NIS metric from [1].
 
 ### Visualization
 

--- a/docs/designs/innovation_filtering.md
+++ b/docs/designs/innovation_filtering.md
@@ -162,15 +162,19 @@ an approach like scikit-learn's
 
 #### Metric / Score Function
 
-Metric to minimize: Normalize innovation squared (NIS). NIS is defined as
+Metric to minimize: Normalized Innovation Squared (NIS). NIS is defined as
 
-$$e_z = z - h(x)
-S = H P H^{T} + R
-NIS = e_z^{T} S^{-1} e_z$$
+$$\tilde{z} = z - \hat{z}
+S = H \overline{\Sigma} H^{T} + Q
+NIS = \tilde{z}^{T} S^{-1} \tilde{z}$$
 
-Roughly, it looks at the magnitude of the reading error $e_z$ vs the expected
-variation $S$. FormaK uses the NIS metric because it doesn't require ground
-truth data. An alternative, "NEES" looks at the errors vs ground truth.
+Roughly, it looks at the magnitude of the reading error $\tilde{z}$ vs the
+expected variation $S$. FormaK uses the NIS metric because it doesn't require
+ground truth data. An alternative, Normalized Estimation Error Squared (NEES)
+looks at the errors vs ground truth. [3]
+
+[3] NEES definition taken from "Kalman Filter Tuning with Bayesian
+Optimization" by Chen et. al.
 
 One small problem with this measure:
 1. The score will decrease consistently as the size of the error goes down (this is good, this means that the model is more accurate

--- a/docs/designs/innovation_filtering.md
+++ b/docs/designs/innovation_filtering.md
@@ -1,6 +1,6 @@
 # Innovation Filtering
 
-Author: Buck Baskin @bebaskin
+Author: Buck Baskin @buck@fosstodon.org
 Created: 2023-08-04
 Updated: 2023-08-04
 Parent Design: [designs/sklearn-integration.md](../designs/sklearn-integration.md)

--- a/docs/designs/innovation_filtering.md
+++ b/docs/designs/innovation_filtering.md
@@ -248,3 +248,39 @@ Additional testing should be performed on measurements and filters of multiple s
 
 Revise to a consistent mathematical notation. Also document a revision in how
 the math for innovation filtering is stated.
+
+### 2023-09-18
+
+[Someone Dead Ruined My Life... Again.](https://www.youtube.com/watch?v=qEV9qoup2mQ)
+
+A refactor ruined my ~life~ implementation of this feature.
+
+In the previous implementation
+[PR #17](https://github.com/buckbaskin/formak/pull/17/), I'd run into an issue
+where the state elements and reading elements were not in the order I expected
+or specified. For a state `{"mass", "z", "v", "a"}` the state would be
+generated as `["a", "mass", "v", "z"]`, so `np.array([[0.0, 1.0, 0.0,0.0]])`
+sets the `mass` to `1.0`, but if I renamed `z` to `b` it'd be silently setting
+`b` to 1.0 instead.
+
+This potential for reordering will ultimately be a feature (where the code
+generation can reorder values to better pack into memory) but for now it was
+only a surprise and it led to a failing test (better to fail the test than to
+silently fail though).
+
+When I went to implement innovation filtering, I again ran into this issue.
+Logically, the only solution would be to refactor how all data types are stored
+and passed around in the Python implementation of FormaK.
+
+And so, I walked deep into the forest of refactoring. To cut a long story
+short, this took way longer than I wanted. The first notes I have for the start
+of the refactor is 2023-08-13 and the end of the refactor dates roughly to
+2023-09-07, so I spent nearly 3.5 weeks on this refactor to "avoid confusion"
+and instead introduced lots of internal confusion as I was refactoring and
+instead introduced much consternation.
+
+Today marks the end of the design, partly because I have some tests passing but
+mostly because I want to call it done enough, move to the next thing and
+revisit it (and test it more) if I find that it isn't working as intended.
+
+Beware the forest of refactoring.

--- a/docs/designs/innovation_filtering.md
+++ b/docs/designs/innovation_filtering.md
@@ -53,7 +53,7 @@ is adapted from "Advanced Kalman Filtering, Least Squares and Modeling" by
 Bruce P. Gibbs (referred to as [1] or AKFLSM)
 [2] The notion follows the conventioned defined in the
 [Mathematical Glossary](../mathematical-glossary.md) which itself is based on
-"Probabilistic Robotics" by Thrun et. al.
+"Probabilistic Robotics" by Thrun et al.
 
 Innovations take advantage of the property that errors are white (normally
 distributed) when all models are correct and, when operating in steady state,
@@ -174,7 +174,7 @@ ground truth data. An alternative, Normalized Estimation Error Squared (NEES)
 looks at the errors vs ground truth. [3]
 
 [3] NEES definition taken from "Kalman Filter Tuning with Bayesian
-Optimization" by Chen et. al.
+Optimization" by Chen et al.
 
 One small problem with this measure:
 1. The score will decrease consistently as the size of the error goes down (this is good, this means that the model is more accurate

--- a/docs/designs/innovation_filtering.md
+++ b/docs/designs/innovation_filtering.md
@@ -1,0 +1,224 @@
+# Innovation Filtering
+
+Author: Buck Baskin @bebaskin
+Created: 2023-08-04
+Updated: 2023-08-04
+Parent Design: [designs/sklearn-integration.md](../designs/sklearn-integration.md)
+See Also: [designs/python_library_for_model_evaluation.md](../designs/python_library_for_model_evaluation.md), [designs/cpp_library_for_model_evaluation.md](../designs/cpp_library_for_model_evaluation.md)
+Status: 1. Design
+
+
+## Overview
+
+
+FormaK aims to combine symbolic modeling for fast, efficient system modelling
+with code generation to create performant code that is easy to use.
+
+The Five Key Elements the library provides to achieve this user experience are:
+1. Python Interface to define models
+2. Python implementation of the model and supporting tooling
+3. Integration to scikit-learn to leverage the model selection and parameter tuning functions
+4. C++ and Python to C++ interoperability for performance
+5. C++ interfaces to support a variety of model uses
+
+This design focuses on "Integration to scikit-learn to leverage the model
+selection and parameter tuning functions". The end result will be updates to
+Python and C++ models, but the primary effort will be improving the
+scikit-learn tooling. The current implementation provides some of the math for
+the EKF (process update, sensor update); however, that leaves the models open
+to spurious readings. In the current implementation, if a FormaK filter gets a
+reading that is almost infinite, say 1e300, the response of the filter will be
+proportional and the response will cause the EKF to diverge as one or more of
+the states jump to positive infinity. This creates a gap in the filter that
+violates one of the FormaK values: easy to use (perhaps in this case it's
+helpful to think of this as easy to use *correctly*).
+
+This problem is known as jump detection. As the filter considers a sensor
+update the filter measures the divergence of the reading from what the model
+expects and then can reject readings with a divergence that is too large to be
+acceptable.
+
+How should the filter measure this divergence? The filter can use the
+measurement innovation $$\tilde{y} = y - h(x)$$ where y is the measurement, h
+is the measurement model and x is the current state estimate and $\tilde{y}$ is
+the resulting innovation. Given the innovation, the definition of too large can
+be calculated from the expected covariance: $$\tilde{y}^{T} C^{-1} \tilde{y} -
+m > k \sqrt{2m}$$ where $C$ is the expected covariance of the measurement, $m$
+is the dimension of the measurement vector and $k$ is the editing threshold. If
+this inequality is true, then the measurement is "too large" and should be
+filtered (edited). [1]
+
+[1] This approach to innovation filtering, referred to as editing in the text,
+is adapted from "Advanced Kalman Filtering, Least Squares and Modeling" by
+Bruce P. Gibbs (referred to as [1] or AKFLSM)
+
+Innovations take advantage of the property that errors are white (normally
+distributed) when all models are correct and, when operating in steady state,
+most variation in the sensor reading is expected to come from the noise in the
+sensor instead of noise in the state. Intuitively, if the sensor is
+consistently providing low variance updates, the state should converge further
+based on that information until the noise in the state relative to the sensor
+is low.
+
+By implementing innovation filtering, the filter will become much more robust
+to errors in the sensor, the model and the overall system. By hooking into
+values that are already calculated as part of the sensor update there should be
+minimal additional performance cost.
+
+## Solution Approach
+
+The primary class of interest will be the Extended Kalman Filter (EKF)
+implementation and revising the sensor update specifically. This change won't
+require a large change to the structure of the EKF generation in Python or C++,
+but it will be fairly math heavy to ensure the changes are working as intended.
+
+### Innovation Filtering
+
+#### Math
+
+The math has been outlined above:
+$$\tilde{y} = y - Hx$$
+$$C = HPH^{T} + R$$
+$$\tilde{y}^{T} C^{-1} \tilde{y} - m > k \sqrt{2m}$$
+
+To provide the maximum value from the innovation filtering, the calculation of
+whether or not to reject the sensor update should be made as early as possible
+(as soon as $\tilde{y}$ is calculated). That way there is no unnecessary wasted
+computation.
+
+#### Filter Health
+
+Innovation filtering makes the assumption that the model is correct and the
+sensor readings may be errant; however, repeated filtering may indicate that
+the filter has diverged. In this initial implementation, the count of
+innovations that are filtered will be tracked online per-measurement update.
+
+
+#### Other Implementation Details
+
+- Use if constexpr for the innovation filtering calculation if turned on ($k > 0$)
+- Use a continuous value for the editing threshold $k$. Provide $k = 5$ as a default edit threshold based on the textbook recommendation [1]
+
+### Model Selection
+
+In AKFLSM there isn't an immediate discussion of how to select the editing
+threshold $k$ based on time series. The design will provide a sane default, but
+it will also be useful to provide a data-driven function to select the value
+based on prior data.
+
+The editing threshold will be selected via a hyperparameter selection process.
+The high level process is composed of the following elements (from the
+[scikit-learn user guide](https://scikit-learn.org/stable/modules/grid_search.html)):
+- The estimator (with fit and predict operations)
+- a parameter space
+- a method for searching or sampling candidates
+- a cross-validation scheme
+- a score function
+
+The parameter space for this problem is positive floats. The problem could be
+thought of as positive integers (how many standard deviations are acceptable)
+but the positive floats should be easier to optimize as a continuous parameter.
+
+#### Parameter Search
+
+The default method for parameter optimization is
+[exhaustive grid search](https://scikit-learn.org/stable/modules/grid_search.html#exhaustive-grid-search).
+For this problem of selecting a single or reduced set of parameters it should
+be okay to use the baseline; however, the design will include an experiment to
+compare between grid search and randomized search. The benefit of randomized
+search is that a specific budget can be set and the approach will, with high
+probability, find the best result in the same search space as the grid search
+but with fewer iterations.
+
+#### Cross Validation
+
+The
+[cross-validation approach](https://scikit-learn.org/stable/modules/cross_validation.html)
+suggested by scikit-learn to choose the hyperparameter with the highest
+cross-validation score:
+1. Hold aside a test time series that does not overlap with the rest of the data set
+2. Within the remaining data, the training time series, subdivide into different folds where one part of each fold is used to train the model and a subset is used for validation. By selecting many folds, we can reduce the chance that the parameters are overfit to noise in a particular test evaluation.
+3. Perform final scoring against the held out test data.
+
+One thing to note: I've used time series here instead of the usual set because
+time series have an explicit order in their samples so the usual selection of
+folds for cross validation won't apply. Instead, the cross validation will use
+an approach like scikit-learn's
+[`TimeSeriesSplit`](https://scikit-learn.org/stable/modules/generated/sklearn.model_selection.TimeSeriesSplit.html#sklearn.model_selection.TimeSeriesSplit).
+
+#### Metric / Score Function
+
+Metric to minimize: Normalize innovation squared (NIS). NIS is defined as
+
+$$e_z = z - h(x)
+S = H P H^{T} + R
+NIS = e_z^{T} S^{-1} e_z$$
+
+Roughly, it looks at the magnitude of the reading error $e_z$ vs the expected
+variation $S$. FormaK uses the NIS metric because it doesn't require ground
+truth data. An alternative, "NEES" looks at the errors vs ground truth.
+
+One small problem with this measure:
+1. The score will decrease consistently as the size of the error goes down (this is good, this means that the model is more accurate
+2. The score will decrease consistently as the size of the variance goes up (this is bad, the optimization could increase the estimated variance to achieve a better score)
+
+To remedy that, the metric to minimize is consistency instead of the true
+minimum score. Taking advantage of the fact that we know that the errors should
+follow a $\chi^{2}$ distribution, we can calculate consistency as follows:
+
+$$ \xi_{K_{r}} = NIS
+\overline{\xi_K} = \sum_{r=1}^{r=N} \xi_{K_{r}}
+F_{K}^{\chi^{2}} = Prob{\chi^{2}_n < \overline{\xi_K}
+d_{i(k)} = F_{K}^{\chi^{2}} - \dfrac{i(k)}{N_{K}}
+Consistency = \dfrac{1}{N_{K}} \sum_{1}^{N_{K}} \lvert d_{i_{(K)}} \rvert$$
+
+### Visualization
+
+Optional extension: Visualizations
+1. The magnitude of normalized innovations for different parameter tunings over a sequence of reading. This should help the user understand if the parameter is selecting models that are converging and if there are portions of the dataset where many models aren't well fit.
+2. The chi2 distribution for innovations for different parameter tunings. I imagine this would look a lot like ROC curves
+
+### Testing for Better Metrics
+
+- Testing, innovation, consistency, go to the math. Everything else in this feature is built on the metrics being evaluated correctly
+- Test with mocked EKF so you can return a fixed state, covariance to get known innovation from readings
+
+### New Class(es)
+
+This feature may require implementing a new class or classes to interface with
+scikit-learn tooling:
+1. Metric function or class to pass to scikit-learn (see the [`make_scorer`](https://scikit-learn.org/stable/modules/model_evaluation.html#defining-your-scoring-strategy-from-metric-functions) interface)
+2. Dataset class. Most scikit-learn tooling deals in vectors and that may not be fully suitable for the
+
+## Experiments
+
+- Compare grid search and randomized search for parameter evaluation. Optionally, compare with [other search algorithms](https://scikit-learn.org/stable/modules/classes.html#hyper-parameter-optimizers).
+
+## Feature Tests
+
+### Innovation Filtering
+
+- x, y, heading, velocity model
+- Provide heading readings, expect rejecting 180 degree heading errors
+	- Nonlinear model provides clear divergence signal
+
+Additional testing should be performed on measurements and filters of multiple sizes
+
+### Model Selection
+
+1. Compare a correct model with a dataset with arbitrary, incorrect +- 5 std dev noise inserted around other noise that is normally distributed. Selecting parameter should be less than 5
+
+## Roadmap and Process
+
+1. Write a design
+2. Write a feature test(s)
+3A. Experiments
+3B. Build a simple prototype
+4. Pass feature tests
+5. Refactor/cleanup
+6. Build an instructive prototype (e.g. something that looks like the project vision but doesn't need to be the full thing)
+7. Add unit testing, etc
+8. Refactor/cleanup
+9. Write up successes, retro of what changed (so I can check for this in future designs)
+
+## Post Review

--- a/docs/designs/runtime.md
+++ b/docs/designs/runtime.md
@@ -203,7 +203,7 @@ Things I liked:
 
 Added to the design:
 - A `::Tag` type for the filter to aggregate all the various signaling the type needs to do to coordinate with the `ManagedFilter`. We'll see if this design choice holds up.
-- [`SFINAE`](https://en.cppreference.com/w/cpp/language/sfinae): Substitution Failure Is Not An Error. In order to support code generation that may or may not have a `Calibration` type or a `Control` type I opted to use SFINAE to selectively add or remove different interfaces. This was simplified somewhat by using if-constexpr internally, but the interfaces are still messy and it feels very close to repeated code copy-pasting. This generation with different interfaces for the end user is adding additional complication for me, but I hope it continues to fall under the heading of accept complexity on my side to achieve an easier to use / more focused version for users.
+- [`SFINAE`](https://en.cppreference.com/w/cpp/language/sfinae): Substitution Failure Is Not An Error. In order to support code generation that may or may not have a `Calibration` type or a `Control` type I opted to use SFINAE to selectively add or remove different interfaces. This was simplified somewhat by using if-constexpr internally, but the interfaces are still messy and it feels close to repeated code copy-pasting. This generation with different interfaces for the end user is adding additional complication for me, but I hope it continues to fall under the heading of accept complexity on my side to achieve an easier to use / more focused version for users.
 
 Things missing from the final version:
 - Performance guaruntees

--- a/docs/mathematical-glossary.md
+++ b/docs/mathematical-glossary.md
@@ -1,0 +1,29 @@
+# Mathematical Glossary
+
+A collection of mathematical terms and symbols used in FormaK documentation
+
+$\mu_{t}$, $\mu_{t-1}$ state, previous state
+
+$\overline{\mu_{t}}$, intermediate state during computation
+
+$\Sigma_{t}$, $\Sigma_{t-1}$ covariance, previous covariance
+
+$\overline{\Sigma_{t}}$, intermediate covariance during computation
+
+$M_{t}$ process noise
+
+$G_{t}$ process jacobian
+
+$V_{t}$ control jacobain
+
+$z_{t}$ sensor reading
+
+$\hat{z_{t}}$ sensor model prediction
+
+$Q_{t}$ sensor noise
+
+$H_{t}$ sensor jacobian
+
+$S_{t}$ expected sensor reading covariance
+
+$K_{t}$ Kalman gain

--- a/docs/whats-new.md
+++ b/docs/whats-new.md
@@ -2,6 +2,18 @@
 
 Release Notes
 
+## 2023-09-18 Innovation Filtering
+
+Innovation filtering provides error rejection for the Kalman Filter. If
+measurements come in that are sufficiently improbable based on the current
+variance of the system then the measurement will be ignored. This is useful for
+cases such as recieving a heading that is 180 degrees opposed to the current
+estimated heading of the vehicle. Maybe it's helpful, but it's likely an
+erroneous reading.
+
+API Change:
+- Refactored error prone creation of sensor data in favor of a new key-based method
+
 ## 2023-08-04 Introducing FormaK Runtime
 
 Commit [`50eeadc`](https://github.com/buckbaskin/formak/commit/50eeadc69655d288a32b20f5b821b77977dba349)

--- a/experimental/BUILD
+++ b/experimental/BUILD
@@ -199,3 +199,12 @@ py_binary(
     srcs = ["src/ast_compile.py"],
     main = "src/ast_compile.py",
 )
+
+py_binary(
+    name = "graphviz-demo",
+    srcs = ["src/graphviz_demo.py"],
+    main = "src/graphviz_demo.py",
+    deps = [
+        requirement("graphviz"),
+    ],
+)

--- a/experimental/src/graphviz_demo.py
+++ b/experimental/src/graphviz_demo.py
@@ -47,7 +47,7 @@ def enumerate_expression(expr, subgraph_name='<>', *, path=None, approx_cse=Fals
     path.append(render_expr(expr))
 
     for idx, child in enumerate(expr.args):
-        # path.append(idx)
+        path.append(str(idx))
 
         for child_id, child_expr, child_children in enumerate_expression(child, subgraph_name, path=path, approx_cse=approx_cse):
             yield child_id, child_expr, child_children
@@ -55,7 +55,7 @@ def enumerate_expression(expr, subgraph_name='<>', *, path=None, approx_cse=Fals
                 # This is false when yielding a grand-child (child's child)
                 child_ids.append(child_id)
 
-        # path.pop()
+        path.pop()
 
     if len(expr.args) > 0 or not approx_cse:
         id_ = f'{subgraph_name}|' + '|'.join(path)

--- a/experimental/src/graphviz_demo.py
+++ b/experimental/src/graphviz_demo.py
@@ -1,6 +1,6 @@
 from collections import deque
 import sympy
-from sympy import Symbol, sin, cos, expand_trig
+from sympy import Symbol, sin, cos, expand_trig, cse
 from graphviz import Digraph
 
 def make_expr():
@@ -29,33 +29,47 @@ def render_expr(expr):
             return '+'
         elif expr.func == sympy.core.mul.Mul:
             return '*'
+        elif expr.func == sympy.core.power.Pow:
+            return 'Pow'
         elif isinstance(expr.func, sympy.core.function.FunctionClass):
             return str(expr.func)
         else:
             raise ValueError(f'what do with args? expr {expr}, type {type(expr.func)} func {expr.func}')
 
 
-def enumerate_expression(expr, root=None):
-    if root is None:
+def enumerate_expression(expr, subgraph_name='<>', *, path=None, approx_cse=False):
+    if path is None:
         print('enumerating:', expr)
-        root = deque()
+        path = deque()
 
     child_ids = []
 
-    root.append(render_expr(expr))
+    path.append(render_expr(expr))
 
-    for child in expr.args:
-        for child_id, child_expr, child_children in enumerate_expression(child, root):
+    for idx, child in enumerate(expr.args):
+        # path.append(idx)
+
+        for child_id, child_expr, child_children in enumerate_expression(child, subgraph_name, path=path, approx_cse=approx_cse):
             yield child_id, child_expr, child_children
             if child_expr == child:
                 # This is false when yielding a grand-child (child's child)
                 child_ids.append(child_id)
 
-    id_ = 'root|' + '|'.join(root)
+        # path.pop()
+
+    if len(expr.args) > 0 or not approx_cse:
+        id_ = f'{subgraph_name}|' + '|'.join(path)
+    else:
+        id_ = path[-1]
+
     yield id_, expr, child_ids
 
 
-    root.pop()
+    path.pop()
+
+def enumerate_multiple(exprs, subgraph_name='<>', *, path=None):
+    for expr in exprs:
+        yield from enumerate_expression(expr, subgraph_name, path=path, approx_cse=True)
 
 def main():
 
@@ -63,10 +77,38 @@ def main():
 
     dot = Digraph(comment='Compute Graph')
 
-    for id_, expr, child_ids in enumerate_expression(v1):
+    for id_, expr, child_ids in enumerate_expression(v1, 'v1'):
         dot.node(id_, render_expr(expr))
         for child_id in child_ids:
             dot.edge(id_, child_id, constraint='true')
+
+    for id_, expr, child_ids in enumerate_expression(v2, 'v2'):
+        dot.node(id_, render_expr(expr))
+        for child_id in child_ids:
+            dot.edge(id_, child_id, constraint='true')
+
+    replacements, reduced_exprs = cse(v1)
+    print('v1', v1)
+    print('cse', replacements, reduced_exprs)
+    for id_, expr in replacements:
+        print('replacements', id_, '->', expr, '->', [])
+        for id_2, expr_2, child_ids_2 in enumerate_expression(expr, '', approx_cse=True):
+            print('-- replacements', id_2, '->', expr_2, '->', [])
+            dot.node(id_2, render_expr(expr_2), constraint='true')
+            for child_id in child_ids_2:
+                dot.edge(id_2, child_id, constraint='true')
+
+    # take advantage of fall through and depth-first traversal
+    dot.node(str(id_), str(id_))
+    print('Extra edge:', str(id_), '->', id_2)
+    dot.edge(str(id_), id_2, constraint='true')
+
+    for id_, expr, child_ids in enumerate_multiple(reduced_exprs, 'v1_cse'):
+        print('reduced', id_, '->', expr, '->', child_ids)
+        dot.node(id_, render_expr(expr))
+        for child_id in child_ids:
+            dot.edge(id_, child_id, constraint='true')
+
 
     dot.render(view=True)
 

--- a/experimental/src/graphviz_demo.py
+++ b/experimental/src/graphviz_demo.py
@@ -1,0 +1,66 @@
+from collections import deque
+import sympy
+from sympy import Symbol, sin, cos, expand_trig
+from graphviz import Digraph
+
+def make_expr():
+    x = Symbol('x')
+    expr_v1= sin(2*x) + cos(2*x)
+    expr_v2 = expand_trig(expr_v1)
+    return expr_v1, expr_v2
+
+def enumerate_expression(expr, root=None):
+    if root is None:
+        print('enumerating:', expr)
+        root = deque()
+
+    if len(expr.args) == 0:
+        if expr.func == sympy.core.numbers.One:
+            root.append('One')
+        elif expr.func == sympy.core.numbers.Zero:
+            root.append('Zero')
+        elif expr.func == sympy.core.numbers.NegativeOne:
+            root.append('-One')
+        elif expr.func == sympy.core.numbers.Integer:
+            root.append(str(expr))
+        elif expr.func == sympy.core.symbol.Symbol:
+            root.append(str(expr))
+        else:
+            raise ValueError('what do unknown? %s' % (expr,))
+
+    else:
+        print(expr.func, expr.args)
+        if expr.func == sympy.core.add.Add:
+            root.append('+')
+        elif expr.func == sympy.core.mul.Mul:
+            root.append('*')
+        elif isinstance(expr.func, sympy.core.function.FunctionClass):
+            root.append(str(expr.func))
+        else:
+            raise ValueError(f'what do with args? expr {expr}, type {type(expr.func)} func {expr.func}')
+
+    id_ = 'root|' + '|'.join(root)
+    yield id_, expr
+
+    for child in expr.args:
+        yield from enumerate_expression(child, root)
+
+    root.pop()
+
+def main():
+
+    v1, v2 = make_expr()
+
+    for id_, expr in enumerate_expression(v1):
+        print(id_)
+
+    dot = graphviz.Digraph(comment='The Round Table')
+    dot.node('A', 'King Arthur')
+    dot.node('B', 'Sir Bedevere the Wise')
+    dot.node('L', 'Sir Lancelot the Brave')
+    dot.edge('B', 'L', constraint='true')
+
+    dot.render(view=True)
+
+if __name__ == "__main__":
+    main()

--- a/experimental/src/graphviz_demo.py
+++ b/experimental/src/graphviz_demo.py
@@ -24,7 +24,7 @@ def render_expr(expr):
         elif expr.func == sympy.core.symbol.Symbol:
             return str(expr)
         else:
-            raise ValueError("what do unknown? %s" % (expr,))
+            raise ValueError("what do unknown? {}".format(expr))
 
     else:
         if expr.func == sympy.core.add.Add:

--- a/experimental/src/graphviz_demo.py
+++ b/experimental/src/graphviz_demo.py
@@ -9,41 +9,51 @@ def make_expr():
     expr_v2 = expand_trig(expr_v1)
     return expr_v1, expr_v2
 
+def render_expr(expr):
+    if len(expr.args) == 0:
+        if expr.func == sympy.core.numbers.One:
+            return 'One'
+        elif expr.func == sympy.core.numbers.Zero:
+            return 'Zero'
+        elif expr.func == sympy.core.numbers.NegativeOne:
+            return '-One'
+        elif expr.func == sympy.core.numbers.Integer:
+            return str(expr)
+        elif expr.func == sympy.core.symbol.Symbol:
+            return str(expr)
+        else:
+            raise ValueError('what do unknown? %s' % (expr,))
+
+    else:
+        if expr.func == sympy.core.add.Add:
+            return '+'
+        elif expr.func == sympy.core.mul.Mul:
+            return '*'
+        elif isinstance(expr.func, sympy.core.function.FunctionClass):
+            return str(expr.func)
+        else:
+            raise ValueError(f'what do with args? expr {expr}, type {type(expr.func)} func {expr.func}')
+
+
 def enumerate_expression(expr, root=None):
     if root is None:
         print('enumerating:', expr)
         root = deque()
 
-    if len(expr.args) == 0:
-        if expr.func == sympy.core.numbers.One:
-            root.append('One')
-        elif expr.func == sympy.core.numbers.Zero:
-            root.append('Zero')
-        elif expr.func == sympy.core.numbers.NegativeOne:
-            root.append('-One')
-        elif expr.func == sympy.core.numbers.Integer:
-            root.append(str(expr))
-        elif expr.func == sympy.core.symbol.Symbol:
-            root.append(str(expr))
-        else:
-            raise ValueError('what do unknown? %s' % (expr,))
+    child_ids = []
 
-    else:
-        print(expr.func, expr.args)
-        if expr.func == sympy.core.add.Add:
-            root.append('+')
-        elif expr.func == sympy.core.mul.Mul:
-            root.append('*')
-        elif isinstance(expr.func, sympy.core.function.FunctionClass):
-            root.append(str(expr.func))
-        else:
-            raise ValueError(f'what do with args? expr {expr}, type {type(expr.func)} func {expr.func}')
-
-    id_ = 'root|' + '|'.join(root)
-    yield id_, expr
+    root.append(render_expr(expr))
 
     for child in expr.args:
-        yield from enumerate_expression(child, root)
+        for child_id, child_expr, child_children in enumerate_expression(child, root):
+            yield child_id, child_expr, child_children
+            if child_expr == child:
+                # This is false when yielding a grand-child (child's child)
+                child_ids.append(child_id)
+
+    id_ = 'root|' + '|'.join(root)
+    yield id_, expr, child_ids
+
 
     root.pop()
 
@@ -51,14 +61,12 @@ def main():
 
     v1, v2 = make_expr()
 
-    for id_, expr in enumerate_expression(v1):
-        print(id_)
+    dot = Digraph(comment='Compute Graph')
 
-    dot = graphviz.Digraph(comment='The Round Table')
-    dot.node('A', 'King Arthur')
-    dot.node('B', 'Sir Bedevere the Wise')
-    dot.node('L', 'Sir Lancelot the Brave')
-    dot.edge('B', 'L', constraint='true')
+    for id_, expr, child_ids in enumerate_expression(v1):
+        dot.node(id_, render_expr(expr))
+        for child_id in child_ids:
+            dot.edge(id_, child_id, constraint='true')
 
     dot.render(view=True)
 

--- a/experimental/src/graphviz_demo.py
+++ b/experimental/src/graphviz_demo.py
@@ -3,43 +3,47 @@ import sympy
 from sympy import Symbol, sin, cos, expand_trig, cse
 from graphviz import Digraph
 
+
 def make_expr():
-    x = Symbol('x')
-    expr_v1= sin(2*x) + cos(2*x)
+    x = Symbol("x")
+    expr_v1 = sin(2 * x) + cos(2 * x)
     expr_v2 = expand_trig(expr_v1)
     return expr_v1, expr_v2
+
 
 def render_expr(expr):
     if len(expr.args) == 0:
         if expr.func == sympy.core.numbers.One:
-            return 'One'
+            return "One"
         elif expr.func == sympy.core.numbers.Zero:
-            return 'Zero'
+            return "Zero"
         elif expr.func == sympy.core.numbers.NegativeOne:
-            return '-One'
+            return "-One"
         elif expr.func == sympy.core.numbers.Integer:
             return str(expr)
         elif expr.func == sympy.core.symbol.Symbol:
             return str(expr)
         else:
-            raise ValueError('what do unknown? %s' % (expr,))
+            raise ValueError("what do unknown? %s" % (expr,))
 
     else:
         if expr.func == sympy.core.add.Add:
-            return '+'
+            return "+"
         elif expr.func == sympy.core.mul.Mul:
-            return '*'
+            return "*"
         elif expr.func == sympy.core.power.Pow:
-            return 'Pow'
+            return "Pow"
         elif isinstance(expr.func, sympy.core.function.FunctionClass):
             return str(expr.func)
         else:
-            raise ValueError(f'what do with args? expr {expr}, type {type(expr.func)} func {expr.func}')
+            raise ValueError(
+                f"what do with args? expr {expr}, type {type(expr.func)} func {expr.func}"
+            )
 
 
-def enumerate_expression(expr, subgraph_name='<>', *, path=None, approx_cse=False):
+def enumerate_expression(expr, subgraph_name="<>", *, path=None, approx_cse=False):
     if path is None:
-        print('enumerating:', expr)
+        print("enumerating:", expr)
         path = deque()
 
     child_ids = []
@@ -49,7 +53,9 @@ def enumerate_expression(expr, subgraph_name='<>', *, path=None, approx_cse=Fals
     for idx, child in enumerate(expr.args):
         path.append(str(idx))
 
-        for child_id, child_expr, child_children in enumerate_expression(child, subgraph_name, path=path, approx_cse=approx_cse):
+        for child_id, child_expr, child_children in enumerate_expression(
+            child, subgraph_name, path=path, approx_cse=approx_cse
+        ):
             yield child_id, child_expr, child_children
             if child_expr == child:
                 # This is false when yielding a grand-child (child's child)
@@ -58,59 +64,62 @@ def enumerate_expression(expr, subgraph_name='<>', *, path=None, approx_cse=Fals
         path.pop()
 
     if len(expr.args) > 0 or not approx_cse:
-        id_ = f'{subgraph_name}|' + '|'.join(path)
+        id_ = f"{subgraph_name}|" + "|".join(path)
     else:
         id_ = path[-1]
 
     yield id_, expr, child_ids
 
-
     path.pop()
 
-def enumerate_multiple(exprs, subgraph_name='<>', *, path=None):
+
+def enumerate_multiple(exprs, subgraph_name="<>", *, path=None):
     for expr in exprs:
         yield from enumerate_expression(expr, subgraph_name, path=path, approx_cse=True)
+
 
 def main():
 
     v1, v2 = make_expr()
 
-    dot = Digraph(comment='Compute Graph')
+    dot = Digraph(comment="Compute Graph")
 
-    for id_, expr, child_ids in enumerate_expression(v1, 'v1'):
+    for id_, expr, child_ids in enumerate_expression(v1, "v1"):
         dot.node(id_, render_expr(expr))
         for child_id in child_ids:
-            dot.edge(id_, child_id, constraint='true')
+            dot.edge(id_, child_id, constraint="true")
 
-    for id_, expr, child_ids in enumerate_expression(v2, 'v2'):
+    for id_, expr, child_ids in enumerate_expression(v2, "v2"):
         dot.node(id_, render_expr(expr))
         for child_id in child_ids:
-            dot.edge(id_, child_id, constraint='true')
+            dot.edge(id_, child_id, constraint="true")
 
     replacements, reduced_exprs = cse(v1)
-    print('v1', v1)
-    print('cse', replacements, reduced_exprs)
+    print("v1", v1)
+    print("cse", replacements, reduced_exprs)
     for id_, expr in replacements:
-        print('replacements', id_, '->', expr, '->', [])
-        for id_2, expr_2, child_ids_2 in enumerate_expression(expr, '', approx_cse=True):
-            print('-- replacements', id_2, '->', expr_2, '->', [])
-            dot.node(id_2, render_expr(expr_2), constraint='true')
+        print("replacements", id_, "->", expr, "->", [])
+        for id_2, expr_2, child_ids_2 in enumerate_expression(
+            expr, "", approx_cse=True
+        ):
+            print("-- replacements", id_2, "->", expr_2, "->", [])
+            dot.node(id_2, render_expr(expr_2), constraint="true")
             for child_id in child_ids_2:
-                dot.edge(id_2, child_id, constraint='true')
+                dot.edge(id_2, child_id, constraint="true")
 
     # take advantage of fall through and depth-first traversal
     dot.node(str(id_), str(id_))
-    print('Extra edge:', str(id_), '->', id_2)
-    dot.edge(str(id_), id_2, constraint='true')
+    print("Extra edge:", str(id_), "->", id_2)
+    dot.edge(str(id_), id_2, constraint="true")
 
-    for id_, expr, child_ids in enumerate_multiple(reduced_exprs, 'v1_cse'):
-        print('reduced', id_, '->', expr, '->', child_ids)
+    for id_, expr, child_ids in enumerate_multiple(reduced_exprs, "v1_cse"):
+        print("reduced", id_, "->", expr, "->", child_ids)
         dot.node(id_, render_expr(expr))
         for child_id in child_ids:
-            dot.edge(id_, child_id, constraint='true')
-
+            dot.edge(id_, child_id, constraint="true")
 
     dot.render(view=True)
+
 
 if __name__ == "__main__":
     main()

--- a/featuretests/ast_code_generation/ast_test.cpp
+++ b/featuretests/ast_code_generation/ast_test.cpp
@@ -1,3 +1,9 @@
+/// Feature Test: AST Code Generation
+///
+/// The code in example.h is generated via the FormaK AST tooling.
+/// Passes if the test compiles without warnings and pass some basic
+/// functionality in testing.
+
 #include <example.h>
 #include <gtest/gtest.h>
 

--- a/featuretests/common_subexpression_elimination/simple_test.cpp
+++ b/featuretests/common_subexpression_elimination/simple_test.cpp
@@ -1,3 +1,9 @@
+/// Feature Test
+///
+/// Create a model with excessive duplication, then generate it with and without
+/// common subexpression elimination.
+/// Passes if CSE demonstrates a significant outperformance in all examples.
+
 #include <cse/cse-model.h>  // Generated
 #include <formak/utils/microbenchmark.h>
 #include <gtest/gtest.h>

--- a/featuretests/common_subexpression_elimination/simple_test.py
+++ b/featuretests/common_subexpression_elimination/simple_test.py
@@ -19,7 +19,9 @@ def test_python_CSE():
 
     # random -> random_sample in 1.25
     inputs = np.random.default_rng(seed=1).random((101, 2))
-    inputs = [np.array([[left, right]]).transpose() for left, right in inputs]
+    inputs = [
+        cse_implementation.State(left=left, right=right) for left, right in inputs
+    ]
 
     # run with CSE, without CSE
     print("CSE")

--- a/featuretests/common_subexpression_elimination/simple_test.py
+++ b/featuretests/common_subexpression_elimination/simple_test.py
@@ -1,3 +1,10 @@
+"""
+Feature Test.
+
+Create a model with excessive duplication, then generate it with and without
+common subexpression elimination.
+Passes if CSE demonstrates a significant outperformance in all examples.
+"""
 from functools import partial
 
 import numpy as np

--- a/featuretests/cpp_library_for_model_evaluation/generator_ekf.py
+++ b/featuretests/cpp_library_for_model_evaluation/generator_ekf.py
@@ -18,13 +18,15 @@ state_model = {
     tp["a"]: -9.81 * tp["mass"] + thrust,
 }
 
+v = ui.Symbol("v")
+
 model = ui.Model(dt=dt, state=state, control=control, state_model=state_model)
 
 cpp_implementation = cpp.compile_ekf(
     state_model=model,
     process_noise={thrust: 1.0},
-    sensor_models={"simple": {ui.Symbol("v"): ui.Symbol("v")}},
-    sensor_noises={"simple": np.eye(1)},
+    sensor_models={"simple": {v: v}},
+    sensor_noises={"simple": {v: 1.0}},
 )
 
 print("Wrote header at path {}".format(cpp_implementation.header_path))

--- a/featuretests/cpp_library_for_model_evaluation/generator_ekf.py
+++ b/featuretests/cpp_library_for_model_evaluation/generator_ekf.py
@@ -1,5 +1,3 @@
-import numpy as np
-
 from formak import cpp, ui
 
 dt = ui.Symbol("dt")

--- a/featuretests/cpp_library_for_model_evaluation/simple_test.cpp
+++ b/featuretests/cpp_library_for_model_evaluation/simple_test.cpp
@@ -1,3 +1,8 @@
+/// Feature Test
+///
+/// Generate a Model in C++ and test a model iteration.
+/// Passes if the model matches the definition.
+
 #include <formak/cpp-model.h>  // Generated
 #include <gtest/gtest.h>
 

--- a/featuretests/cpp_library_for_model_evaluation/simple_to_ekf_test.cpp
+++ b/featuretests/cpp_library_for_model_evaluation/simple_to_ekf_test.cpp
@@ -1,3 +1,8 @@
+/// Feature Test
+///
+/// Generate an EKF in C++. Test a model iteration and a sensor update.
+/// Passes if the updates match the expected model
+
 #include <formak/cpp-ekf.h>  // Generated
 #include <gtest/gtest.h>
 

--- a/featuretests/innovation_filtering/BUILD
+++ b/featuretests/innovation_filtering/BUILD
@@ -1,0 +1,31 @@
+load("@pip_deps//:requirements.bzl", "requirement")
+load("//py:defs.bzl", "cc_formak_model", "cc_test_suite", "py_test_suite")
+load("@bazel_skylib//rules:run_binary.bzl", "run_binary")
+load("//featuretests:test_deps.bzl", "CC_FEATURE_TEST_DEPS", "PY_FEATURE_TEST_DEPS")
+
+py_test_suite(
+    name = "nonlinear-test-py",
+    srcs = ["nonlinear_test.py"],
+    deps = ["//py:formak"] + PY_FEATURE_TEST_DEPS,
+)
+
+cc_formak_model(
+    name = "nonlinear",
+    namespace = "featuretest",
+    pydeps = [],
+    pymain = "generator.py",
+    pysrcs = glob(
+        ["*.py"],
+        allow_empty = False,
+    ),
+)
+
+cc_test(
+    name = "nonlinear-test-cpp",
+    srcs = ["nonlinear_test.cpp"],
+    deps =
+        [
+            "//cpp/runtime:managed-filter",
+            ":nonlinear",
+        ] + CC_FEATURE_TEST_DEPS,
+)

--- a/featuretests/innovation_filtering/generator.py
+++ b/featuretests/innovation_filtering/generator.py
@@ -1,5 +1,5 @@
 """
-Innovation Filtering Featuretest
+Innovation Filtering Featuretest.
 
 Create a model with states:
 - x, y, heading, velocity model
@@ -8,7 +8,7 @@ Provide heading readings, expect rejecting 180 degree heading errors.
 Nonlinear model provides clear divergence signal. If innovation filtering isn't
 working as expected, then the model will flip into the wrong direction.
 """
-from math import degrees, radians
+from math import radians
 
 from sympy import cos, sin
 

--- a/featuretests/innovation_filtering/generator.py
+++ b/featuretests/innovation_filtering/generator.py
@@ -10,7 +10,6 @@ working as expected, then the model will flip into the wrong direction.
 """
 from math import degrees, radians
 
-import numpy as np
 from sympy import cos, sin
 
 from formak import cpp, ui

--- a/featuretests/innovation_filtering/generator.py
+++ b/featuretests/innovation_filtering/generator.py
@@ -39,7 +39,7 @@ cpp_implementation = cpp.compile_ekf(
     state_model=model,
     process_noise={velocity: 1.0, _heading_err: 0.1},
     sensor_models={"compass": {heading: heading}},
-    sensor_noises={"compass": TRUE_SCALE * np.eye(1)},
+    sensor_noises={"compass": {heading: TRUE_SCALE}},
     config=config,
 )
 

--- a/featuretests/innovation_filtering/generator.py
+++ b/featuretests/innovation_filtering/generator.py
@@ -1,0 +1,35 @@
+import numpy as np
+
+from formak import cpp, ui
+
+dt = ui.Symbol("dt")
+
+tp = trajectory_properties = {k: ui.Symbol(k) for k in ["mass", "z", "v", "a"]}
+
+thrust = ui.Symbol("thrust")
+
+state = set(tp.values())
+control = {thrust}
+
+state_model = {
+    tp["mass"]: tp["mass"],
+    tp["z"]: tp["z"] + dt * tp["v"],
+    tp["v"]: tp["v"] + dt * tp["a"],
+    tp["a"]: -9.81 * tp["mass"] + thrust,
+}
+
+model = ui.Model(dt=dt, state=state, control=control, state_model=state_model)
+
+cpp_implementation = cpp.compile_ekf(
+    state_model=model,
+    process_noise={thrust: 1.0},
+    sensor_models={
+        "simple": {ui.Symbol("v"): ui.Symbol("v")},
+        "accel": {ui.Symbol("a"): ui.Symbol("a")},
+    },
+    sensor_noises={"simple": np.eye(1), "accel": np.eye(1)},
+    config={"common_subexpression_elimination": True, "max_dt_sec": 0.05},
+)
+
+print("Wrote header at path {}".format(cpp_implementation.header_path))
+print("Wrote source at path {}".format(cpp_implementation.source_path))

--- a/featuretests/innovation_filtering/nonlinear_test.cpp
+++ b/featuretests/innovation_filtering/nonlinear_test.cpp
@@ -1,3 +1,15 @@
+/// Innovation Filtering Feature Test
+///
+/// Create a model with states:
+/// - x, y, heading, velocity model
+///
+/// Provide heading readings, expect rejecting 180 degree heading errors.
+/// Nonlinear model provides clear divergence signal. If innovation filtering
+/// isn't working as expected, then the model will flip into the wrong
+/// direction.
+///
+/// Passes if the model rejects the high innovation updates.
+
 #include <featuretest/nonlinear.h>
 #include <formak/runtime/ManagedFilter.h>
 #include <gtest/gtest.h>

--- a/featuretests/innovation_filtering/nonlinear_test.cpp
+++ b/featuretests/innovation_filtering/nonlinear_test.cpp
@@ -2,6 +2,8 @@
 #include <formak/runtime/ManagedFilter.h>
 #include <gtest/gtest.h>
 
+#include <random>
+
 namespace featuretest {
 
 namespace {
@@ -17,68 +19,56 @@ constexpr double degrees(double radians) {
 constexpr double TRUE_SCALE = radians(5.0);
 }  // namespace
 
+std::vector<double> rng(size_t size, size_t seed = 1) {
+  std::minstd_rand prng(seed);
+  std::normal_distribution<> dist(0, TRUE_SCALE);
+
+  std::vector<double> result;
+
+  for (size_t i = 0; i < size; i++) {
+    result.push_back(dist(prng));
+  }
+
+  return result;
+}
+
 TEST(InnovationFilteringTest, ObviousInnovationRejections) {
-  // ekf, compass_model = make_ekf()
-  // # Note: state = heading, x, y
-  // state = np.array([[0.0, 1.0, 0.0]]).transpose()
-  // covariance = np.eye(3)
   featuretest::State state({
       .heading = 0.0,
       .x = 1.0,
       .y = 0.0,
   });
+  ASSERT_DOUBLE_EQ(state.heading(), 0.0);
 
-  // control = np.array([[0.0, 1.0]]).transpose()
   featuretest::Control control({
-      ._heading_err = 1.0,
-      .velocity = 0.0,
+      ._heading_err = 0.0,
+      .velocity = 1.0,
   });
 
-  // mf = runtime.ManagedFilter(
-  //     ekf=ekf, start_time=0.0, state=state, covariance=covariance
-  // )
   formak::runtime::ManagedFilter<featuretest::ExtendedKalmanFilter> mf(
       0.0, {
                .state = state,
                .covariance = {},
            });
 
-  // readings = np.random.default_rng(seed=3).normal(
-  //     loc=0.0, scale=TRUE_SCALE / 2.0, size=(100,)
-  // )
-  std::vector<double> readings;
+  std::vector<double> readings = rng(100, 3);
 
-  ASSERT_GT(readings.size(), 0);
-  // readings[readings.shape[0] // 4] = radians(180.0)
-  // readings[readings.shape[0] // 3] = radians(180.0)
-  // readings[readings.shape[0] // 2] = radians(180.0)
+  ASSERT_EQ(readings.size(), 100);
   readings[readings.size() / 4] = radians(180.0);
   readings[readings.size() / 3] = radians(180.0);
   readings[readings.size() / 2] = radians(180.0);
 
-  // TODO(buck): for loop
-  // for idx, r in enumerate(readings):
-  //     s = mf.tick(
-  //         0.1 * idx,
-  //         control=control,
-  //         readings=[
-  //             runtime.StampedReading(0.1 * idx - 0.05, "compass",
-  //             np.array([[r]]))
-  //         ],
-  //     )
   for (size_t idx = 0; idx < readings.size(); ++idx) {
     auto r = readings[idx];
-    auto s = mf.tick(0.1, control);
+    auto s = mf.tick(
+        idx * 0.1, control,
+        {
+            mf.wrap<Compass>(idx * 0.1 - 0.05, CompassOptions{.heading = r}),
+        });
 
-    // TODO(buck): assertions in for loop
-    //     if abs(compass_model(s.state)) >= TRUE_SCALE * 4:
-    //         print({"idx": idx, "reading": degrees(r)})
-    //     assert abs(compass_model(s.state)) < TRUE_SCALE * 4
     ASSERT_LT(std::abs(s.state.heading()), TRUE_SCALE * 4)
         << "idx: " << idx << " reading: " << degrees(r);
   }
-
-  FAIL() << "Not Implemented";
 }
 
 }  // namespace featuretest

--- a/featuretests/innovation_filtering/nonlinear_test.cpp
+++ b/featuretests/innovation_filtering/nonlinear_test.cpp
@@ -1,0 +1,9 @@
+#include <gtest/gtest.h>
+
+namespace featuretest {
+
+TEST(InnovationFilteringTest, ObviousInnovationRejections) {
+  FAIL() << "Not Implemented";
+}
+
+}  // namespace featuretest

--- a/featuretests/innovation_filtering/nonlinear_test.cpp
+++ b/featuretests/innovation_filtering/nonlinear_test.cpp
@@ -1,8 +1,62 @@
+#include <featuretest/nonlinear.h>
 #include <gtest/gtest.h>
 
 namespace featuretest {
 
+double radians(double degrees) {
+  // Precision isn't important, but probably should be changed for a std math
+  // operation
+  return degrees / 180 * 3.14159;
+}
+
 TEST(InnovationFilteringTest, ObviousInnovationRejections) {
+  // ekf, compass_model = make_ekf()
+  // # Note: state = heading, x, y
+  // state = np.array([[0.0, 1.0, 0.0]]).transpose()
+  // covariance = np.eye(3)
+  featuretest::State state(
+      featuretest::StateOptions{.x = 1.0, .y = 0.0, .heading = 0.0});
+
+  // control = np.array([[0.0, 1.0]]).transpose()
+  featuretest::Control control{.velocity = 0.0, ._heading_err = 1.0};
+
+  // mf = runtime.ManagedFilter(
+  //     ekf=ekf, start_time=0.0, state=state, covariance=covariance
+  // )
+  formak::runtime::ManagedFilter<featuretest::ExtendedKalmanFilter> mf(
+      0.0, {
+               .state = state,
+               .covariance = {},
+           });
+
+  // readings = np.random.default_rng(seed=3).normal(
+  //     loc=0.0, scale=TRUE_SCALE / 2.0, size=(100,)
+  // )
+  std::vector<double> readings;
+
+  // readings[readings.shape[0] // 4] = radians(180.0)
+  // readings[readings.shape[0] // 3] = radians(180.0)
+  // readings[readings.shape[0] // 2] = radians(180.0)
+  readings[readings.size() / 4] = radians(180.0);
+  readings[readings.size() / 3] = radians(180.0);
+  readings[readings.size() / 2] = radians(180.0);
+
+  // TODO(buck): for loop
+  // for idx, r in enumerate(readings):
+  //     s = mf.tick(
+  //         0.1 * idx,
+  //         control=control,
+  //         readings=[
+  //             runtime.StampedReading(0.1 * idx - 0.05, "compass",
+  //             np.array([[r]]))
+  //         ],
+  //     )
+  auto state0p1 = mf.tick(0.1, control);
+
+  // TODO(buck): assertions in for loop
+  //     if abs(compass_model(s.state)) >= TRUE_SCALE * 4:
+  //         print({"idx": idx, "reading": degrees(r)})
+  //     assert abs(compass_model(s.state)) < TRUE_SCALE * 4
   FAIL() << "Not Implemented";
 }
 

--- a/featuretests/innovation_filtering/nonlinear_test.py
+++ b/featuretests/innovation_filtering/nonlinear_test.py
@@ -51,8 +51,7 @@ def make_ekf():
 
 def test_obvious_innovation_rejections():
     ekf, compass_model = make_ekf()
-    # Note: state = heading, x, y
-    state = ekf.make_state({"x": 1.0, "y": 0.0, "heading": 0.0})
+    state = ekf.make_state(x=1.0, y=0.0, heading=0.0, example=0.0)
     covariance = ekf.make_variance({"x": 1.0, "y": 1.0, "heading": 1.0})
     control = ekf.make_control({"velocity": 1.0})
     mf = runtime.ManagedFilter(

--- a/featuretests/innovation_filtering/nonlinear_test.py
+++ b/featuretests/innovation_filtering/nonlinear_test.py
@@ -1,5 +1,5 @@
 """
-Innovation Filtering Featuretest
+Innovation Filtering Feature Test.
 
 Create a model with states:
 - x, y, heading, velocity model
@@ -7,6 +7,8 @@ Create a model with states:
 Provide heading readings, expect rejecting 180 degree heading errors.
 Nonlinear model provides clear divergence signal. If innovation filtering isn't
 working as expected, then the model will flip into the wrong direction.
+
+Passes if the model rejects the high innovation updates.
 """
 from math import degrees, radians
 

--- a/featuretests/innovation_filtering/nonlinear_test.py
+++ b/featuretests/innovation_filtering/nonlinear_test.py
@@ -79,6 +79,6 @@ def test_obvious_innovation_rejections():
             ],
         )
 
-        if abs(compass_model(s.state)) >= TRUE_SCALE * 4:
+        if abs(compass_model(s.state).data) >= TRUE_SCALE * 4:
             print({"idx": idx, "reading": degrees(r)})
-        assert abs(compass_model(s.state)) < TRUE_SCALE * 4
+        assert abs(compass_model(s.state).data) < TRUE_SCALE * 4

--- a/featuretests/innovation_filtering/nonlinear_test.py
+++ b/featuretests/innovation_filtering/nonlinear_test.py
@@ -51,9 +51,9 @@ def make_ekf():
 
 def test_obvious_innovation_rejections():
     ekf, compass_model = make_ekf()
-    state = ekf.make_state(x=1.0, y=0.0, heading=0.0, example=0.0)
-    covariance = ekf.make_variance({"x": 1.0, "y": 1.0, "heading": 1.0})
-    control = ekf.make_control({"velocity": 1.0})
+    state = ekf.make_state(x=1.0, y=0.0, heading=0.0)
+    covariance = ekf.make_variance(x=1.0, y=1.0, heading=1.0)
+    control = ekf.make_control(velocity=1.0)
     mf = runtime.ManagedFilter(
         ekf=ekf, start_time=0.0, state=state, covariance=covariance
     )
@@ -72,7 +72,7 @@ def test_obvious_innovation_rejections():
             control=control,
             readings=[
                 runtime.StampedReading(
-                    0.1 * idx - 0.05, "compass", ekf.make_reading("compass", r)
+                    0.1 * idx - 0.05, "compass", ekf.make_reading("compass", heading=r)
                 )
             ],
         )

--- a/featuretests/innovation_filtering/nonlinear_test.py
+++ b/featuretests/innovation_filtering/nonlinear_test.py
@@ -35,7 +35,7 @@ def make_ekf():
 
     model = ui.Model(dt=dt, state=state, control=control, state_model=state_model)
 
-    config = python.Config(innovation_filtering=True)
+    config = python.Config(innovation_filtering=4)
 
     ekf = python.compile_ekf(
         state_model=model,

--- a/featuretests/innovation_filtering/nonlinear_test.py
+++ b/featuretests/innovation_filtering/nonlinear_test.py
@@ -49,7 +49,7 @@ def make_ekf():
     return ekf, compass_model.model
 
 
-def test_tick_time_only():
+def test_obvious_innovation_rejections():
     ekf, compass_model = make_ekf()
     # Note: state = heading, x, y
     state = np.array([[0.0, 1.0, 0.0]]).transpose()

--- a/featuretests/innovation_filtering/nonlinear_test.py
+++ b/featuretests/innovation_filtering/nonlinear_test.py
@@ -74,11 +74,7 @@ def test_obvious_innovation_rejections():
         s = mf.tick(
             0.1 * idx,
             control=control,
-            readings=[
-                runtime.StampedReading(
-                    0.1 * idx - 0.05, "compass", ekf.make_reading("compass", heading=r)
-                )
-            ],
+            readings=[runtime.StampedReading(0.1 * idx - 0.05, "compass", heading=r)],
         )
 
         if abs(compass_model(s.state).data) >= TRUE_SCALE * 4:

--- a/featuretests/innovation_filtering/nonlinear_test.py
+++ b/featuretests/innovation_filtering/nonlinear_test.py
@@ -1,0 +1,81 @@
+"""
+Innovation Filtering Featuretest
+
+Create a model with states:
+- x, y, heading, velocity model
+
+Provide heading readings, expect rejecting 180 degree heading errors.
+Nonlinear model provides clear divergence signal. If innovation filtering isn't
+working as expected, then the model will flip into the wrong direction.
+"""
+from math import degrees, radians
+
+import numpy as np
+from sympy import cos, sin
+
+from formak import python, runtime, ui
+
+TRUE_SCALE = radians(5.0)
+
+
+def make_ekf():
+    dt = ui.Symbol("dt")
+
+    x, y, heading, velocity, _heading_err = ui.symbols(
+        ["x", "y", "heading", "velocity", "_heading_err"]
+    )
+    state = {x, y, heading}
+    control = {velocity, _heading_err}
+
+    state_model = {
+        x: x + dt * velocity * cos(heading),
+        y: y + dt * velocity * sin(heading),
+        heading: heading + _heading_err,
+    }
+
+    model = ui.Model(dt=dt, state=state, control=control, state_model=state_model)
+
+    config = python.Config(innovation_filtering=True)
+
+    ekf = python.compile_ekf(
+        state_model=model,
+        process_noise={velocity: 1.0, _heading_err: 0.1},
+        sensor_models={"compass": {heading: heading}},
+        sensor_noises={"compass": TRUE_SCALE * np.eye(1)},
+        config=config,
+    )
+    compass_model = python.SensorModel(model, {heading: heading}, {}, config)
+
+    return ekf, compass_model.model
+
+
+def test_tick_time_only():
+    ekf, compass_model = make_ekf()
+    # Note: state = heading, x, y
+    state = np.array([[0.0, 1.0, 0.0]]).transpose()
+    covariance = np.eye(3)
+    control = np.array([[0.0, 1.0]]).transpose()
+    mf = runtime.ManagedFilter(
+        ekf=ekf, start_time=0.0, state=state, covariance=covariance
+    )
+
+    readings = np.random.default_rng(seed=3).normal(
+        loc=0.0, scale=TRUE_SCALE / 2.0, size=(100,)
+    )
+
+    readings[readings.shape[0] // 4] = radians(180.0)
+    readings[readings.shape[0] // 3] = radians(180.0)
+    readings[readings.shape[0] // 2] = radians(180.0)
+
+    for idx, r in enumerate(readings):
+        s = mf.tick(
+            0.1 * idx,
+            control=control,
+            readings=[
+                runtime.StampedReading(0.1 * idx - 0.05, "compass", np.array([[r]]))
+            ],
+        )
+
+        if abs(compass_model(s.state)) >= TRUE_SCALE * 4:
+            print({"idx": idx, "reading": degrees(r)})
+        assert abs(compass_model(s.state)) < TRUE_SCALE * 4

--- a/featuretests/innovation_filtering/nonlinear_test.py
+++ b/featuretests/innovation_filtering/nonlinear_test.py
@@ -51,9 +51,11 @@ def make_ekf():
 
 def test_obvious_innovation_rejections():
     ekf, compass_model = make_ekf()
-    state = ekf.make_state(x=1.0, y=0.0, heading=0.0)
-    covariance = ekf.make_variance(x=1.0, y=1.0, heading=1.0)
-    control = ekf.make_control(velocity=1.0)
+
+    state = ekf.State(x=1.0, y=0.0, heading=0.0)
+    covariance = ekf.Covariance(x=1.0, y=1.0, heading=1.0)
+    control = ekf.Control(velocity=1.0)
+
     mf = runtime.ManagedFilter(
         ekf=ekf, start_time=0.0, state=state, covariance=covariance
     )

--- a/featuretests/managed_filter/generator.py
+++ b/featuretests/managed_filter/generator.py
@@ -1,5 +1,3 @@
-import numpy as np
-
 from formak import cpp, ui
 
 dt = ui.Symbol("dt")

--- a/featuretests/managed_filter/generator.py
+++ b/featuretests/managed_filter/generator.py
@@ -27,7 +27,7 @@ cpp_implementation = cpp.compile_ekf(
         "simple": {ui.Symbol("v"): ui.Symbol("v")},
         "accel": {ui.Symbol("a"): ui.Symbol("a")},
     },
-    sensor_noises={"simple": np.eye(1), "accel": np.eye(1)},
+    sensor_noises={"simple": {tp["v"]: 1.0}, "accel": {tp["a"]: 1.0}},
     config={"common_subexpression_elimination": True, "max_dt_sec": 0.05},
 )
 

--- a/featuretests/managed_filter/tick_interface_test.cpp
+++ b/featuretests/managed_filter/tick_interface_test.cpp
@@ -1,3 +1,11 @@
+/// Feature Test
+///
+/// Run the new ManagedFilter with a generated EKF. Run it with and without
+/// sensor readings.
+///
+/// Passes if the ManagedFilter updates the state (other testing checks if it's
+/// working correctly).
+
 #include <featuretest/example.h>  // Generated
 #include <formak/runtime/ManagedFilter.h>
 #include <gtest/gtest.h>

--- a/featuretests/managed_filter/tick_interface_test.py
+++ b/featuretests/managed_filter/tick_interface_test.py
@@ -21,13 +21,15 @@ def make_ekf():
         tp["a"]: -9.81 * tp["mass"] + thrust,
     }
 
+    v = ui.Symbol("v")
+
     model = ui.Model(dt=dt, state=state, control=control, state_model=state_model)
 
     ekf = python.compile_ekf(
         state_model=model,
         process_noise={thrust: 1.0},
-        sensor_models={"simple": {ui.Symbol("v"): ui.Symbol("v")}},
-        sensor_noises={"simple": np.eye(1)},
+        sensor_models={"simple": {v: v}},
+        sensor_noises={"simple": {v: 1.0}},
     )
     return ekf
 

--- a/featuretests/managed_filter/tick_interface_test.py
+++ b/featuretests/managed_filter/tick_interface_test.py
@@ -36,9 +36,9 @@ def make_ekf():
 
 def test_tick_time_only():
     ekf = make_ekf()
-    state = np.array([[0.0, 1.0, 0.0, 0.0]]).transpose()
-    covariance = np.eye(4)
-    control = np.array([[0.0]])
+    state = ekf.State(v=1.0)
+    covariance = ekf.Covariance()
+    control = ekf.Control()
     mf = ManagedFilter(ekf=ekf, start_time=0.0, state=state, covariance=covariance)
 
     state0p1 = mf.tick(0.1, control=control)
@@ -50,9 +50,9 @@ def test_tick_time_only():
 
 def test_tick_empty_sensor_readings():
     ekf = make_ekf()
-    state = np.array([[0.0, 1.0, 0.0, 0.0]]).transpose()
-    covariance = np.eye(4)
-    control = np.array([[0.0]])
+    state = ekf.State(v=1.0)
+    covariance = ekf.Covariance()
+    control = ekf.Control()
     mf = ManagedFilter(ekf=ekf, start_time=2.0, state=state, covariance=covariance)
 
     state0p1 = mf.tick(2.1, control=control, readings=[])
@@ -64,16 +64,16 @@ def test_tick_empty_sensor_readings():
 
 def test_tick_one_sensor_reading():
     ekf = make_ekf()
-    state = np.array([[0.0, 1.0, 0.0, 0.0]]).transpose()
-    covariance = np.eye(4)
-    control = np.array([[0.0]])
+    state = ekf.State(v=1.0)
+    covariance = ekf.Covariance()
+    control = ekf.Control()
     mf = ManagedFilter(ekf=ekf, start_time=2.0, state=state, covariance=covariance)
 
-    reading1 = StampedReading(2.05, "simple", np.zeros((1, 1)))
+    reading1 = StampedReading(2.05, "simple", ekf.make_reading("simple"))
 
     state0p1 = mf.tick(2.1, control=control, readings=[reading1])
 
-    reading2 = StampedReading(2.15, "simple", np.zeros((1, 1)))
+    reading2 = StampedReading(2.15, "simple", ekf.make_reading("simple"))
 
     state0p2 = mf.tick(2.2, control=control, readings=[reading2])
 
@@ -82,23 +82,23 @@ def test_tick_one_sensor_reading():
 
 def test_tick_multiple_sensor_reading():
     ekf = make_ekf()
-    state = np.array([[0.0, 1.0, 0.0, 0.0]]).transpose()
-    covariance = np.eye(4)
-    control = np.array([[0.0]])
+    state = ekf.State(v=1.0)
+    covariance = ekf.Covariance()
+    control = ekf.Control()
     mf = ManagedFilter(ekf=ekf, start_time=3.0, state=state, covariance=covariance)
 
     readings1 = [
-        StampedReading(3.05, "simple", np.zeros((1, 1))),
-        StampedReading(3.06, "simple", np.zeros((1, 1))),
-        StampedReading(3.07, "simple", np.zeros((1, 1))),
+        StampedReading(3.05, "simple", ekf.make_reading("simple")),
+        StampedReading(3.06, "simple", ekf.make_reading("simple")),
+        StampedReading(3.07, "simple", ekf.make_reading("simple")),
     ]
 
     state0p1 = mf.tick(3.1, control=control, readings=readings1)
 
     readings2 = [
-        StampedReading(3.15, "simple", np.zeros((1, 1))),
-        StampedReading(3.16, "simple", np.zeros((1, 1))),
-        StampedReading(3.17, "simple", np.zeros((1, 1))),
+        StampedReading(3.15, "simple", ekf.make_reading("simple")),
+        StampedReading(3.16, "simple", ekf.make_reading("simple")),
+        StampedReading(3.17, "simple", ekf.make_reading("simple")),
     ]
 
     state0p2 = mf.tick(3.2, control=control, readings=readings2)

--- a/featuretests/managed_filter/tick_interface_test.py
+++ b/featuretests/managed_filter/tick_interface_test.py
@@ -77,11 +77,11 @@ def test_tick_one_sensor_reading():
     control = ekf.Control()
     mf = ManagedFilter(ekf=ekf, start_time=2.0, state=state, covariance=covariance)
 
-    reading1 = StampedReading(2.05, "simple", ekf.make_reading("simple"))
+    reading1 = StampedReading(2.05, "simple")
 
     state0p1 = mf.tick(2.1, control=control, readings=[reading1])
 
-    reading2 = StampedReading(2.15, "simple", ekf.make_reading("simple"))
+    reading2 = StampedReading(2.15, "simple")
 
     state0p2 = mf.tick(2.2, control=control, readings=[reading2])
 
@@ -96,17 +96,17 @@ def test_tick_multiple_sensor_reading():
     mf = ManagedFilter(ekf=ekf, start_time=3.0, state=state, covariance=covariance)
 
     readings1 = [
-        StampedReading(3.05, "simple", ekf.make_reading("simple")),
-        StampedReading(3.06, "simple", ekf.make_reading("simple")),
-        StampedReading(3.07, "simple", ekf.make_reading("simple")),
+        StampedReading(3.05, "simple"),
+        StampedReading(3.06, "simple"),
+        StampedReading(3.07, "simple"),
     ]
 
     state0p1 = mf.tick(3.1, control=control, readings=readings1)
 
     readings2 = [
-        StampedReading(3.15, "simple", ekf.make_reading("simple")),
-        StampedReading(3.16, "simple", ekf.make_reading("simple")),
-        StampedReading(3.17, "simple", ekf.make_reading("simple")),
+        StampedReading(3.15, "simple"),
+        StampedReading(3.16, "simple"),
+        StampedReading(3.17, "simple"),
     ]
 
     state0p2 = mf.tick(3.2, control=control, readings=readings2)

--- a/featuretests/managed_filter/tick_interface_test.py
+++ b/featuretests/managed_filter/tick_interface_test.py
@@ -1,3 +1,11 @@
+"""
+Feature Test.
+
+Run the new ManagedFilter with a generated EKF. Run it with and without sensor readings.
+
+Passes if the ManagedFilter updates the state (other testing checks if it's
+working correctly).
+"""
 import numpy as np
 from formak.runtime import ManagedFilter, StampedReading
 

--- a/featuretests/python_library_for_model_evaluation/simple_test.py
+++ b/featuretests/python_library_for_model_evaluation/simple_test.py
@@ -24,7 +24,7 @@ def test_python_Model_simple():
 
     python_implementation = python.compile(model)
 
-    state_vector = np.array([[0.0, 0.0, 0.0, 0.0]]).transpose()
-    control_vector = np.array([[0.0]])
+    state_vector = python_implementation.State()
+    control_vector = python_implementation.Control()
 
     _state_vector_next = python_implementation.model(0.1, state_vector, control_vector)

--- a/featuretests/python_library_for_model_evaluation/simple_test.py
+++ b/featuretests/python_library_for_model_evaluation/simple_test.py
@@ -1,5 +1,10 @@
-import numpy as np
+"""
+Feature Test.
 
+Create a Python model
+
+Passes if the Python model runs
+"""
 from formak import python, ui
 
 

--- a/featuretests/python_library_for_model_evaluation/simple_to_ekf_test.py
+++ b/featuretests/python_library_for_model_evaluation/simple_to_ekf_test.py
@@ -22,11 +22,13 @@ def test_ekf_simple():
 
     model = ui.Model(dt=dt, state=state, control=control, state_model=state_model)
 
+    v = ui.Symbol("v")
+
     python_ekf = python.compile_ekf(
         state_model=model,
         process_noise={thrust: 1.0},
-        sensor_models={"simple": {ui.Symbol("v"): ui.Symbol("v")}},
-        sensor_noises={"simple": np.eye(1)},
+        sensor_models={"simple": {v: v}},
+        sensor_noises={"simple": {v: 1.0}},
     )
     assert isinstance(python_ekf, python.ExtendedKalmanFilter)
 

--- a/featuretests/python_library_for_model_evaluation/simple_to_ekf_test.py
+++ b/featuretests/python_library_for_model_evaluation/simple_to_ekf_test.py
@@ -32,9 +32,9 @@ def test_ekf_simple():
     )
     assert isinstance(python_ekf, python.ExtendedKalmanFilter)
 
-    state_vector = np.array([[0.0, 0.0, 0.0, 0.0]]).transpose()
-    state_variance = np.eye(4)
-    control_vector = np.array([[0.0]])
+    state_vector = python_ekf.State()
+    state_variance = python_ekf.Covariance()
+    control_vector = python_ekf.Control()
 
     state_vector_next, state_variance_next = python_ekf.process_model(
         0.1, state_vector, state_variance, control_vector
@@ -44,5 +44,5 @@ def test_ekf_simple():
         state=state_vector,
         covariance=state_variance,
         sensor_key="simple",
-        sensor_reading=np.array([[0.0]]),
+        sensor_reading=python_ekf.make_reading("simple", v=0.0),
     )

--- a/featuretests/python_library_for_model_evaluation/simple_to_ekf_test.py
+++ b/featuretests/python_library_for_model_evaluation/simple_to_ekf_test.py
@@ -1,5 +1,10 @@
-import numpy as np
+"""
+Feature Test.
 
+Create a Python implementation of an EKF.
+
+Passes if the EKF runs without exceptions
+"""
 from formak import python, ui
 
 

--- a/featuretests/python_ui_demo/orbital_test.py
+++ b/featuretests/python_ui_demo/orbital_test.py
@@ -1,3 +1,10 @@
+"""
+Feature Test.
+
+Lay out a new model based on a simplified rocket
+
+Passes if the Model is constructed without exceptions
+"""
 from collections import defaultdict
 
 from formak import ui

--- a/featuretests/python_ui_demo/simple_test.py
+++ b/featuretests/python_ui_demo/simple_test.py
@@ -1,3 +1,10 @@
+"""
+Feature Test.
+
+Lay out a new model
+
+Passes if the Model is constructed without exceptions
+"""
 from formak import ui
 
 

--- a/featuretests/rocket_model/ekf_cpp_test.py
+++ b/featuretests/rocket_model/ekf_cpp_test.py
@@ -46,6 +46,6 @@ def test_cpp_EKF():
         sensor_models={
             "altitude": {ui.Symbol("altitude"): CON_position_in_global_frame[2]}
         },
-        sensor_noises={"altitude": np.eye(1)},
+        sensor_noises={"altitude": {ui.Symbol("altitude"): 1.0}},
         calibration_map=calibration_map,
     )

--- a/featuretests/rocket_model/ekf_cpp_test.py
+++ b/featuretests/rocket_model/ekf_cpp_test.py
@@ -1,6 +1,12 @@
+"""
+Feature Test.
+
+Define a C++ implementation of a rocket model
+
+Passes if the C++ implementation is written to disk without an exception
+"""
 from itertools import repeat
 
-import numpy as np
 from model_definition import (
     model_definition,
     named_acceleration,

--- a/featuretests/rocket_model/ekf_py_test.py
+++ b/featuretests/rocket_model/ekf_py_test.py
@@ -1,6 +1,13 @@
+"""
+Feature Test.
+
+Define a Python implementation of a rocket model. This previously demonstrated
+some performance limitations for the Python generation with a bigger model.
+
+Passes if the Python implementation is created and runs without an exception
+"""
 from itertools import repeat
 
-import numpy as np
 from model_definition import (
     model_definition,
     named_acceleration,

--- a/featuretests/rocket_model/ekf_py_test.py
+++ b/featuretests/rocket_model/ekf_py_test.py
@@ -46,7 +46,7 @@ def test_python_EKF():
         sensor_models={
             "altitude": {ui.Symbol("altitude"): CON_position_in_global_frame[2]}
         },
-        sensor_noises={"altitude": np.eye(1)},
+        sensor_noises={"altitude": {ui.Symbol("altitude"): 1.0}},
         calibration_map=calibration_map,
     )
 

--- a/featuretests/rocket_model/ekf_py_test.py
+++ b/featuretests/rocket_model/ekf_py_test.py
@@ -50,9 +50,9 @@ def test_python_EKF():
         calibration_map=calibration_map,
     )
 
-    state_vector = np.zeros((9, 1))
-    state_covariance = np.eye(9)
-    control_vector = np.zeros((6, 1))
+    state_vector = python_implementation.State()
+    state_covariance = python_implementation.Covariance()
+    control_vector = python_implementation.Control()
 
     _state_vector_next = python_implementation.process_model(
         dt=0.01, state=state_vector, covariance=state_covariance, control=control_vector

--- a/featuretests/rocket_model/ekf_test.cpp
+++ b/featuretests/rocket_model/ekf_test.cpp
@@ -1,3 +1,11 @@
+/// Feature Test
+///
+/// Define a C++ implementation of a rocket model. This previously demonstrated
+/// some performance limitations for the C++ generation with a bigger model.
+///
+/// Passes if the C++ implementation is compiled and runs meeting basic model
+/// checks
+
 #include <featuretest/cpp-rocket-model.h>  // Generated
 #include <gtest/gtest.h>
 

--- a/featuretests/rocket_model/generator.py
+++ b/featuretests/rocket_model/generator.py
@@ -44,7 +44,7 @@ cpp_implementation = cpp.compile_ekf(
     sensor_models={
         "altitude": {ui.Symbol("altitude"): CON_position_in_global_frame[2]}
     },
-    sensor_noises={"altitude": np.eye(1)},
+    sensor_noises={"altitude": {"altitude": 1.0}},
     calibration_map=calibration_map,
     config=cpp.Config(common_subexpression_elimination=True),
 )

--- a/featuretests/rocket_model/generator.py
+++ b/featuretests/rocket_model/generator.py
@@ -1,6 +1,5 @@
 from itertools import repeat
 
-import numpy as np
 from model_definition import (
     model_definition,
     named_acceleration,

--- a/featuretests/rocket_model/model_cpp_test.py
+++ b/featuretests/rocket_model/model_cpp_test.py
@@ -1,3 +1,10 @@
+"""
+Feature Test.
+
+Define a C++ implementation of a rocket model
+
+Passes if the C++ implementation is written to disk without an exception
+"""
 from model_definition import model_definition
 
 from formak import cpp, ui

--- a/featuretests/rocket_model/model_py_test.py
+++ b/featuretests/rocket_model/model_py_test.py
@@ -25,8 +25,8 @@ def test_python_Model():
         calibration_map=calibration_map,
     )
 
-    state_vector = np.zeros((9, 1))
-    control_vector = np.zeros((6, 1))
+    state_vector = python_implementation.State()
+    control_vector = python_implementation.Control()
 
     _state_vector_next = python_implementation.model(
         dt=0.01,

--- a/featuretests/rocket_model/model_py_test.py
+++ b/featuretests/rocket_model/model_py_test.py
@@ -1,4 +1,11 @@
-import numpy as np
+"""
+Feature Test.
+
+Define a Python implementation of a rocket model. This previously demonstrated
+some performance limitations for the Python generation with a bigger model.
+
+Passes if the Python implementation is created and runs without an exception
+"""
 from model_definition import model_definition
 
 from formak import python, ui

--- a/featuretests/scikit_learn_integration/pipeline_test.py
+++ b/featuretests/scikit_learn_integration/pipeline_test.py
@@ -1,3 +1,8 @@
+"""
+Feature Test.
+
+Passes if running a model in a pipeline doesn't raise exceptions
+"""
 import numpy as np
 from sklearn.pipeline import Pipeline
 

--- a/featuretests/scikit_learn_integration/pipeline_test.py
+++ b/featuretests/scikit_learn_integration/pipeline_test.py
@@ -24,7 +24,7 @@ def test_like_sklearn_regression():
     params = {
         "process_noise": {ui.Symbol("thrust"): 1.0},
         "sensor_models": {"simple": {ui.Symbol("v"): ui.Symbol("v")}},
-        "sensor_noises": {"simple": np.eye(1)},
+        "sensor_noises": {"simple": {ui.Symbol("v"): 1.0}},
     }
     model = python.compile_ekf(
         ui.Model(dt=dt, state=state, control=control, state_model=state_model), **params

--- a/featuretests/scikit_learn_integration/simple_regression_test.py
+++ b/featuretests/scikit_learn_integration/simple_regression_test.py
@@ -26,7 +26,7 @@ def test_like_sklearn_regression():
             "z": {ui.Symbol("z"): ui.Symbol("z")},
             "v": {ui.Symbol("v"): ui.Symbol("v")},
         },
-        "sensor_noises": {"z": np.eye(1), "v": np.eye(1)},
+        "sensor_noises": {"z": {ui.Symbol("z"): 1.0}, "v": {ui.Symbol("v"): 1.0}},
     }
     model = python.compile_ekf(
         ui.Model(dt=dt, state=state, control=control, state_model=state_model), **params

--- a/featuretests/scikit_learn_integration/simple_regression_test.py
+++ b/featuretests/scikit_learn_integration/simple_regression_test.py
@@ -1,3 +1,10 @@
+"""
+Feature Test.
+
+Fit a Python model via the scikit-learn interface.
+
+Passes if the fit model scores better than the unfit model
+"""
 import numpy as np
 
 from formak import python, ui

--- a/featuretests/scikit_learn_integration/ui_test.py
+++ b/featuretests/scikit_learn_integration/ui_test.py
@@ -23,7 +23,7 @@ def test_UI_like_sklearn():
     params = {
         "process_noise": {thrust: 1.0},
         "sensor_models": {"simple": {ui.Symbol("v"): ui.Symbol("v")}},
-        "sensor_noises": {"simple": np.eye(1)},
+        "sensor_noises": {"simple": {ui.Symbol("v"): 1.0}},
     }
 
     model = python.compile_ekf(

--- a/featuretests/scikit_learn_integration/ui_test.py
+++ b/featuretests/scikit_learn_integration/ui_test.py
@@ -1,3 +1,12 @@
+"""
+Feature Test.
+
+Generate a Python model and run it against a handful of tests that exercise a
+scikit-learn-like interface
+
+Passes if the interfaces return results that match the expected shape of each
+scikit-learn interface
+"""
 import numpy as np
 
 from formak import python, ui

--- a/py/formak/common.py
+++ b/py/formak/common.py
@@ -122,6 +122,7 @@ def named_vector(name, arglist):
     class _NamedVector(_NamedArrayBase):
         _name = name
         _arglist = arglist
+
         def __init__(self, *, _data=None, **kwargs):
             super().__init__(name, kwargs)
 
@@ -150,7 +151,6 @@ def named_vector(name, arglist):
                 and cls.shape() == Other.shape()
             )
 
-
         @classmethod
         def shape(cls):
             return (len(arglist), 1)
@@ -162,6 +162,7 @@ def named_covariance(name, arglist):
     class _NamedCovariance(_NamedArrayBase):
         _name = name
         _arglist = arglist
+
         def __init__(self, *, _data=None, **kwargs):
             super().__init__(name, kwargs)
 
@@ -189,6 +190,7 @@ def named_covariance(name, arglist):
                 and cls._arglist == Other._arglist
                 and cls.shape() == Other.shape()
             )
+
         @classmethod
         def shape(cls):
             return (len(arglist), len(arglist))

--- a/py/formak/common.py
+++ b/py/formak/common.py
@@ -1,6 +1,8 @@
+import types
 from itertools import product
 from typing import Dict, Tuple, Union
 
+import numpy as np
 from formak.exceptions import ModelConstructionError
 from sympy import Symbol, diff
 from sympy.solvers.solveset import nonlinsolve
@@ -91,3 +93,27 @@ def model_validation(
             raise ModelConstructionError(
                 f"Model has solutions in state space where covariance will collapse to zero. Example Solutions:\n -{solution_repr}"
             )
+
+
+def named_vector(name, arglist):
+    class _NamedVector:
+        def __init__(self, **kwargs):
+            self._kwargs = kwargs
+
+            allowed_keys = [str(arg) for arg in arglist]
+            for key in kwargs:
+                if key not in allowed_keys:
+                    raise TypeError(
+                        f"{name}() got an unexpected keyword argument {key}"
+                    )
+
+            self.data = np.zeros((len(arglist), 1))
+            for idx, key in enumerate(allowed_keys):
+                if key in kwargs:
+                    self.data[idx, 0] = kwargs[key]
+
+        def __repr__(self):
+            kwargs = ", ".join(f"{k}={v}" for k, v in self._kwargs.items())
+            return f"{name}({kwargs})"
+
+    return types.new_class(name, bases=(_NamedVector,))

--- a/py/formak/common.py
+++ b/py/formak/common.py
@@ -117,3 +117,27 @@ def named_vector(name, arglist):
             return f"{name}({kwargs})"
 
     return types.new_class(name, bases=(_NamedVector,))
+
+
+def named_covariance(name, arglist):
+    class _NamedCovariance:
+        def __init__(self, **kwargs):
+            self._kwargs = kwargs
+
+            allowed_keys = [str(arg) for arg in arglist]
+            for key in kwargs:
+                if key not in allowed_keys:
+                    raise TypeError(
+                        f"{name}() got an unexpected keyword argument {key}"
+                    )
+
+            self.data = np.eye(len(arglist))
+            for idx, key in enumerate(allowed_keys):
+                if key in kwargs:
+                    self.data[idx, idx] = kwargs[key]
+
+        def __repr__(self):
+            kwargs = ", ".join(f"{k}={v}" for k, v in self._kwargs.items())
+            return f"{name}({kwargs})"
+
+    return types.new_class(name, bases=(_NamedCovariance,))

--- a/py/formak/common.py
+++ b/py/formak/common.py
@@ -117,6 +117,10 @@ class _NamedArrayBase(abc.ABC):
         assert data.shape == cls.shape()
         return cls(_data=data)
 
+    @classmethod
+    def from_dict(cls, mapping):
+        return cls(**{str(k): v for k, v in mapping.items()})
+
 
 def named_vector(name, arglist):
     class _NamedVector(_NamedArrayBase):

--- a/py/formak/common.py
+++ b/py/formak/common.py
@@ -149,7 +149,16 @@ def named_vector(name, arglist):
 
         @classmethod
         def __subclasshook__(cls, Other):
-            print('cls', name, cls._arglist, cls.shape(), 'Other', Other.__name__, Other._arglist, Other.shape())
+            print(
+                "cls",
+                name,
+                cls._arglist,
+                cls.shape(),
+                "Other",
+                Other.__name__,
+                Other._arglist,
+                Other.shape(),
+            )
             return (
                 Other.__name__ == name
                 and cls._arglist == Other._arglist

--- a/py/formak/common.py
+++ b/py/formak/common.py
@@ -6,6 +6,14 @@ from sympy import Symbol, diff
 from sympy.solvers.solveset import nonlinsolve
 
 
+class UiModelBase:
+    """
+    Use as a base class for ui.Model, but in a separate file from ui.Model so that formak.python doesn't directly depend on formak.ui just for typing
+    """
+
+    pass
+
+
 def model_validation(
     state_model,
     process_noise: Dict[Union[Symbol, Tuple[Symbol, Symbol]], float],

--- a/py/formak/common.py
+++ b/py/formak/common.py
@@ -97,8 +97,9 @@ def model_validation(
 
 
 class _NamedArrayBase(abc.ABC):
-    def __init__(self, name):
+    def __init__(self, name, kwargs):
         self.name = name
+        self._kwargs = kwargs
 
     def __repr__(self):
         kwargs = ", ".join(f"{k}={v}" for k, v in self._kwargs.items())
@@ -119,9 +120,10 @@ class _NamedArrayBase(abc.ABC):
 
 def named_vector(name, arglist):
     class _NamedVector(_NamedArrayBase):
+        _name = name
+        _arglist = arglist
         def __init__(self, *, _data=None, **kwargs):
-            super().__init__(name)
-            self._kwargs = kwargs
+            super().__init__(name, kwargs)
 
             allowed_keys = [str(arg) for arg in arglist]
             for key in kwargs:
@@ -142,14 +144,12 @@ def named_vector(name, arglist):
 
         @classmethod
         def __subclasshook__(cls, Other):
-            print(Other, Other.__name__)
-            print(Other.arglist)
-            1 / 0
             return (
                 Other.__name__ == name
-                and arglist == Other.arglist
+                and cls._arglist == Other._arglist
                 and cls.shape() == Other.shape()
             )
+
 
         @classmethod
         def shape(cls):
@@ -160,9 +160,10 @@ def named_vector(name, arglist):
 
 def named_covariance(name, arglist):
     class _NamedCovariance(_NamedArrayBase):
+        _name = name
+        _arglist = arglist
         def __init__(self, *, _data=None, **kwargs):
-            super().__init__(name)
-            self._kwargs = kwargs
+            super().__init__(name, kwargs)
 
             allowed_keys = [str(arg) for arg in arglist]
             for key in kwargs:
@@ -183,15 +184,11 @@ def named_covariance(name, arglist):
 
         @classmethod
         def __subclasshook__(cls, Other):
-            print(Other, Other.__name__)
-            print(Other.arglist)
-            1 / 0
             return (
                 Other.__name__ == name
-                and arglist == Other.arglist
+                and cls._arglist == Other._arglist
                 and cls.shape() == Other.shape()
             )
-
         @classmethod
         def shape(cls):
             return (len(arglist), len(arglist))

--- a/py/formak/common.py
+++ b/py/formak/common.py
@@ -149,6 +149,7 @@ def named_vector(name, arglist):
 
         @classmethod
         def __subclasshook__(cls, Other):
+            print('cls', name, cls._arglist, cls.shape(), 'Other', Other.__name__, Other._arglist, Other.shape())
             return (
                 Other.__name__ == name
                 and cls._arglist == Other._arglist

--- a/py/formak/common.py
+++ b/py/formak/common.py
@@ -147,16 +147,16 @@ def named_vector(name, arglist):
 
         @classmethod
         def __subclasshook__(cls, Other):
-            print(
-                "cls",
-                name,
-                cls._arglist,
-                cls.shape,
-                "Other",
-                Other.__name__,
-                Other._arglist if hasattr(Other, "_arglist") else None,
-                Other.shape if hasattr(Other, "shape") else None,
-            )
+            # print(
+            #     "cls",
+            #     name,
+            #     cls._arglist,
+            #     cls.shape,
+            #     "Other",
+            #     Other.__name__,
+            #     Other._arglist if hasattr(Other, "_arglist") else None,
+            #     Other.shape if hasattr(Other, "shape") else None,
+            # )
             return (
                 Other.__name__ == name
                 and cls._arglist == Other._arglist

--- a/py/formak/common.py
+++ b/py/formak/common.py
@@ -10,11 +10,7 @@ from sympy.solvers.solveset import nonlinsolve
 
 
 class UiModelBase:
-    """
-    Use as a base class for ui.Model, but in a separate file from ui.Model so that formak.python doesn't directly depend on formak.ui just for typing
-    """
-
-    pass
+    """Use as a base class for ui.Model, but in a separate file from ui.Model so that formak.python doesn't directly depend on formak.ui just for typing."""
 
 
 def model_validation(
@@ -118,6 +114,10 @@ class _NamedArrayBase(abc.ABC):
     def from_dict(cls, mapping):
         return cls(**{str(k): v for k, v in mapping.items()})
 
+    @classmethod
+    def __subclasshook__(cls, Other):
+        raise NotImplementedError()
+
 
 def named_vector(name, arglist):
     class _NamedVector(_NamedArrayBase):
@@ -147,16 +147,6 @@ def named_vector(name, arglist):
 
         @classmethod
         def __subclasshook__(cls, Other):
-            # print(
-            #     "cls",
-            #     name,
-            #     cls._arglist,
-            #     cls.shape,
-            #     "Other",
-            #     Other.__name__,
-            #     Other._arglist if hasattr(Other, "_arglist") else None,
-            #     Other.shape if hasattr(Other, "shape") else None,
-            # )
             return (
                 Other.__name__ == name
                 and cls._arglist == Other._arglist

--- a/py/formak/cpp.py
+++ b/py/formak/cpp.py
@@ -75,7 +75,7 @@ class Config:
                         MemberDeclaration(
                             "static constexpr double",
                             "innovation_filtering",
-                            self.innovation_filtering,
+                            self.innovation_filtering if self.innovation_filtering else 0.0,
                         ),
                     ],
                 )

--- a/py/formak/cpp.py
+++ b/py/formak/cpp.py
@@ -41,6 +41,7 @@ class Config:
     common_subexpression_elimination: bool = True
     extra_validation: bool = False
     max_dt_sec: float = 0.1
+    innovation_filtering: float = 5.0
 
     def ccode(self):
         if self.max_dt_sec < 1e-9:
@@ -70,6 +71,11 @@ class Config:
                         ),
                         MemberDeclaration(
                             "static constexpr double", "max_dt_sec", self.max_dt_sec
+                        ),
+                        MemberDeclaration(
+                            "static constexpr double",
+                            "innovation_filtering",
+                            self.innovation_filtering,
                         ),
                     ],
                 )

--- a/py/formak/cpp.py
+++ b/py/formak/cpp.py
@@ -758,6 +758,7 @@ def header_from_ast(*, generator) -> str:
     includes = [
         "#include <Eigen/Dense>    // Matrix",
         "#include <iostream>",
+        "#include <formak/innovation_filtering.h>",
     ]
     if generator.enable_EKF:
         # TODO(buck): Remove this when innovations moved to ManagedFilter

--- a/py/formak/cpp.py
+++ b/py/formak/cpp.py
@@ -567,7 +567,9 @@ class ExtendedKalmanFilter:
             )
             SensorModel_model_body = list(body.compile()) + [return_]
 
-            SensorCovariance = common.named_covariance(f'{name}Covariance', arglist_sensor)
+            SensorCovariance = common.named_covariance(
+                f"{name}Covariance", arglist_sensor
+            )
 
             SensorModel_covariance_body = self._translate_sensor_covariance(
                 typename, SensorCovariance.from_dict(sensor_noise)

--- a/py/formak/cpp.py
+++ b/py/formak/cpp.py
@@ -638,7 +638,7 @@ class ExtendedKalmanFilter:
         yield Return("jacobian")
 
     def _translate_sensor_covariance_impl(self, covariance):
-        rows, cols = covariance.shape()
+        rows, cols = covariance.shape
         for i in range(rows):
             for j in range(cols):
                 yield f"covariance({i}, {j})", covariance.data[i, j]

--- a/py/formak/cpp.py
+++ b/py/formak/cpp.py
@@ -172,6 +172,10 @@ class Model:
             + self.arglist_control
         )
 
+        self.State = common.named_vector("State", self.arglist_state)
+        self.Control = common.named_vector("Control", self.arglist_control)
+        self.Calibration = common.named_vector("Calibration", self.arglist_calibration)
+
         if self.calibration_size > 0:
             if len(calibration_map) == 0:
                 map_lite = "\n  , ".join(
@@ -306,6 +310,11 @@ class ExtendedKalmanFilter:
             + self.arglist_calibration
             + self.arglist_control
         )
+
+        self.State = common.named_vector("State", self.arglist_state)
+        self.Covariance = common.named_covariance("Covariance", self.arglist_state)
+        self.Control = common.named_vector("Control", self.arglist_control)
+        self.Calibration = common.named_vector("Calibration", self.arglist_calibration)
 
         if self.calibration_size > 0:
             if len(calibration_map) == 0:

--- a/py/formak/cpp.py
+++ b/py/formak/cpp.py
@@ -75,7 +75,9 @@ class Config:
                         MemberDeclaration(
                             "static constexpr double",
                             "innovation_filtering",
-                            self.innovation_filtering if self.innovation_filtering else 0.0,
+                            self.innovation_filtering
+                            if self.innovation_filtering
+                            else 0.0,
                         ),
                     ],
                 )

--- a/py/formak/cpp.py
+++ b/py/formak/cpp.py
@@ -757,11 +757,9 @@ def header_from_ast(*, generator) -> str:
     )
     includes = [
         "#include <Eigen/Dense>    // Matrix",
-        "#include <iostream>",
         "#include <formak/innovation_filtering.h>",
     ]
     if generator.enable_EKF:
-        # TODO(buck): Remove this when innovations moved to ManagedFilter
         includes.append("#include <any>")
         includes.append("#include <optional>")
         includes.append("#include <type_traits>")  # false_type

--- a/py/formak/cpp.py
+++ b/py/formak/cpp.py
@@ -741,6 +741,7 @@ def header_from_ast(*, generator) -> str:
     )
     includes = [
         "#include <Eigen/Dense>    // Matrix",
+        "#include <iostream>",
     ]
     if generator.enable_EKF:
         # TODO(buck): Remove this when innovations moved to ManagedFilter

--- a/py/formak/python.py
+++ b/py/formak/python.py
@@ -564,7 +564,9 @@ class ExtendedKalmanFilter:
         )
         S_inv = np.linalg.inv(S_t)
 
-        self.innovations[sensor_key] = innovation = sensor_reading.data - expected_reading.data
+        self.innovations[sensor_key] = innovation = (
+            sensor_reading.data - expected_reading.data
+        )
 
         if self.config.innovation_filtering is not None:
             editing_threshold = self.config.innovation_filtering

--- a/py/formak/python.py
+++ b/py/formak/python.py
@@ -442,6 +442,21 @@ class ExtendedKalmanFilter:
         self.innovations = {}
         self.sensor_prediction_uncertainty = {}
 
+    def make_state(self, **kwargs):
+        allowed_keys = [str(arg) for arg in self.arglist_state]
+        for key in kwargs:
+            if key not in allowed_keys:
+                raise TypeError(
+                    f"make_state() got an unexpected keyword argument {key}"
+                )
+
+        state = np.zeros((self.state_size, 1))
+        for idx, key in enumerate(allowed_keys):
+            print(key, kwargs)
+            if key in kwargs:
+                state[key, 0] = kwargs[key]
+        return state
+
     def process_jacobian(self, dt, state, control):
         computed_jacobian = list(
             self._impl_process_jacobian.execute(

--- a/py/formak/python.py
+++ b/py/formak/python.py
@@ -715,8 +715,8 @@ class ExtendedKalmanFilter:
 
         dt = 0.1
 
-        state = np.zeros((self.state_size, 1))
-        covariance = np.eye(self.state_size)
+        state = self.State()
+        covariance = self.Covariance()
 
         innovations = []
         states = [state]
@@ -727,7 +727,9 @@ class ExtendedKalmanFilter:
                 X[idx, : self.control_size],
                 X[idx, self.control_size :],
             )
-            controls_input = controls_input.reshape((self.control_size, 1))
+            controls_input = self.Control.from_data(
+                controls_input.reshape((self.control_size, 1))
+            )
 
             state, covariance = self.process_model(
                 dt, state, covariance, controls_input
@@ -742,7 +744,9 @@ class ExtendedKalmanFilter:
                     the_rest[:sensor_size],
                     the_rest[sensor_size:],
                 )
-                sensor_input = sensor_input.reshape((sensor_size, 1))
+                sensor_input = self.make_reading(
+                    key, sensor_input.reshape((sensor_size, 1))
+                )
 
                 state, covariance = self.sensor_model(
                     state=state,

--- a/py/formak/python.py
+++ b/py/formak/python.py
@@ -179,7 +179,7 @@ class Model:
                 raise TypeError(
                     "model() missing 1 required positional argument: 'control_vector'"
                 )
-            control_vector = np.zeros((0, 1))
+            control_vector = self.Control()
 
         try:
             assert isinstance(dt, float)
@@ -495,7 +495,7 @@ class ExtendedKalmanFilter:
 
     def process_model(self, dt, state, covariance, control=None):
         if control is None:
-            control = np.zeros((0, 1))
+            control = self.Control()
 
         try:
             assert isinstance(state, self.State)
@@ -515,15 +515,15 @@ class ExtendedKalmanFilter:
         next_state_covariance = np.matmul(
             G_t, np.matmul(covariance.data, G_t.transpose())
         )
-        assert next_state_covariance.shape == covariance.shape()
+        assert next_state_covariance.shape == covariance.shape
 
         next_control_covariance = np.matmul(
             V_t, np.matmul(self.params["process_noise"], V_t.transpose())
         )
-        assert next_control_covariance.shape == covariance.shape()
+        assert next_control_covariance.shape == covariance.shape
 
         next_covariance = next_state_covariance + next_control_covariance
-        assert next_covariance.shape == covariance.shape()
+        assert next_covariance.shape == covariance.shape
 
         next_state = self._state_model.model(dt, state, control)
         assert isinstance(next_state, self.State)

--- a/py/formak/python.py
+++ b/py/formak/python.py
@@ -452,10 +452,53 @@ class ExtendedKalmanFilter:
 
         state = np.zeros((self.state_size, 1))
         for idx, key in enumerate(allowed_keys):
-            print(key, kwargs)
             if key in kwargs:
-                state[key, 0] = kwargs[key]
+                state[idx, 0] = kwargs[key]
         return state
+
+    def make_variance(self, **kwargs):
+        allowed_keys = [str(arg) for arg in self.arglist_state]
+        for key in kwargs:
+            if key not in allowed_keys:
+                raise TypeError(
+                    f"make_state() got an unexpected keyword argument {key}"
+                )
+
+        state = np.eye(self.state_size)
+        for idx, key in enumerate(allowed_keys):
+            if key in kwargs:
+                state[idx, idx] = kwargs[key]
+        return state
+
+    def make_control(self, **kwargs):
+        allowed_keys = [str(arg) for arg in self._state_model.arglist_control]
+        for key in kwargs:
+            if key not in allowed_keys:
+                raise TypeError(
+                    f"make_control() got an unexpected keyword argument {key}"
+                )
+
+        control = np.zeros((self.control_size, 1))
+        for idx, key in enumerate(allowed_keys):
+            if key in kwargs:
+                control[idx, 0] = kwargs[key]
+        return control
+
+    def make_reading(self, sensor_key, **kwargs):
+        readings = self.params["sensor_models"][sensor_key].readings
+
+        allowed_keys = [str(r) for r in readings]
+        for key in kwargs:
+            if key not in allowed_keys:
+                raise TypeError(
+                    f"make_reading() got an unexpected keyword argument {key}"
+                )
+
+        control = np.zeros((len(readings), 1))
+        for idx, key in enumerate(allowed_keys):
+            if key in kwargs:
+                control[idx, 0] = kwargs[key]
+        return control
 
     def process_jacobian(self, dt, state, control):
         computed_jacobian = list(

--- a/py/formak/python.py
+++ b/py/formak/python.py
@@ -286,7 +286,7 @@ class ExtendedKalmanFilter:
         state_model,
         process_noise: Dict[Union[Symbol, Tuple[Symbol, Symbol]], float],
         sensor_models,
-        sensor_noises,
+        sensor_noises: Dict[Union[Symbol, Tuple[Symbol, Symbol]], float],
         config,
         calibration_map=None,
     ):
@@ -392,6 +392,8 @@ class ExtendedKalmanFilter:
         self, state_model, sensor_models, sensor_noises, calibration_map, config
     ):
         assert set(sensor_models.keys()) == set(sensor_noises.keys())
+        assert isinstance(sensor_noises, dict)
+        assert len(sensor_noises) == len(sensor_models)
 
         self.params["sensor_models"] = {
             k: SensorModel(
@@ -403,10 +405,8 @@ class ExtendedKalmanFilter:
             for k, model in sensor_models.items()
         }
         for k in self.params["sensor_models"].keys():
-            assert sensor_noises[k].shape == (
-                self.params["sensor_models"][k].sensor_size,
-                self.params["sensor_models"][k].sensor_size,
-            )
+            assert isinstance(sensor_noises[k], dict)
+            assert len(sensor_noises[k]) == self.params["sensor_models"][k].sensor_size
 
         self.params["sensor_noises"] = sensor_noises
 

--- a/py/formak/python.py
+++ b/py/formak/python.py
@@ -31,6 +31,7 @@ class Config:
     python_modules = DEFAULT_MODULES
     extra_validation: bool = False
     max_dt_sec: float = 0.1
+    innovation_filtering: float = 5.0
 
 
 class BasicBlock:
@@ -803,7 +804,7 @@ def compile(symbolic_model, calibration_map=None, *, config=None):
 
 
 def compile_ekf(
-    state_model,
+    state_model: common.UiModelBase,
     process_noise: Dict[Union[Symbol, Tuple[Symbol, Symbol]], float],
     sensor_models,
     sensor_noises,

--- a/py/formak/python.py
+++ b/py/formak/python.py
@@ -271,7 +271,7 @@ class SensorModel:
                 if "result" in locals():
                     print("found: {}, {}".format(type(result), result))
                 raise
-        return reading
+        return self.Reading.from_data(reading)
 
 
 StateAndCovariance = namedtuple("StateAndCovariance", ["state", "covariance"])
@@ -560,11 +560,11 @@ class ExtendedKalmanFilter:
         assert H_t.shape == (sensor_size, self.state_size)
 
         self.sensor_prediction_uncertainty[sensor_key] = S_t = (
-            np.matmul(H_t, np.matmul(covariance.data, H_t.transpose())) + Q_t
+            np.matmul(H_t, np.matmul(covariance.data, H_t.transpose())) + Q_t.data
         )
         S_inv = np.linalg.inv(S_t)
 
-        self.innovations[sensor_key] = innovation = sensor_reading - expected_reading
+        self.innovations[sensor_key] = innovation = sensor_reading.data - expected_reading.data
 
         if self.config.innovation_filtering is not None:
             editing_threshold = self.config.innovation_filtering

--- a/py/formak/python.py
+++ b/py/formak/python.py
@@ -193,7 +193,7 @@ class Model:
 
         next_state = self.State(
             **{
-                state_id: result
+                str(state_id): result
                 for state_id, result in zip(
                     self.arglist_state,
                     self._impl.execute(
@@ -244,7 +244,7 @@ class SensorModel:
         return len(self.sensor_models)
 
     def model(self, state_vector):
-        assert isinstance(state_vector, np.ndarray)
+        assert isinstance(state_vector, self.State)
         assert state_vector.shape == (self.state_size, 1)
 
         reading = np.zeros((self.sensor_size, 1))
@@ -589,7 +589,8 @@ class ExtendedKalmanFilter:
         next_covariance = next_state_covariance + next_control_covariance
         assert next_covariance.shape == covariance.shape()
 
-        next_state = self.State.from_data(self._state_model.model(dt, state, control))
+        next_state = self._state_model.model(dt, state, control)
+        assert isinstance(next_state, self.State)
 
         return StateAndCovariance(
             next_state, self.Covariance.from_data(next_covariance)
@@ -601,8 +602,8 @@ class ExtendedKalmanFilter:
         Q_t = _model_noise = self.params["sensor_noises"][sensor_key]
 
         try:
-            assert isinstance(state, np.ndarray)
-            assert isinstance(covariance, np.ndarray)
+            assert isinstance(state, self.State)
+            assert isinstance(covariance, self.Covariance)
             assert isinstance(sensor_reading, np.ndarray)
         except AssertionError:
             print(
@@ -617,8 +618,6 @@ class ExtendedKalmanFilter:
             raise
 
         try:
-            assert state.shape == (self.state_size, 1)
-            assert covariance.shape == (self.state_size, self.state_size)
             assert sensor_reading.shape == (sensor_size, 1)
             assert Q_t.shape == (sensor_size, sensor_size)
         except AssertionError:

--- a/py/formak/runtime.py
+++ b/py/formak/runtime.py
@@ -80,7 +80,4 @@ class ManagedFilter:
                 output_time - iter_time, state, covariance, control
             )
 
-        print("expected_iterations", "self.current_time", "output_time", "iter_time")
-        print(expected_iterations, self.current_time, output_time, iter_time)
-
         return output_time, StateAndVariance(state, covariance)

--- a/py/formak/runtime.py
+++ b/py/formak/runtime.py
@@ -7,7 +7,18 @@ from collections import namedtuple
 from math import floor
 from typing import List, Optional
 
-StampedReading = namedtuple("StampedReading", ["timestamp", "sensor_key", "data"])
+
+class StampedReading(object):
+    def __init__(self, timestamp, sensor_key, *, _data=None, **kwargs):
+        self.timestamp = timestamp
+        self.sensor_key = sensor_key
+        self._data = _data
+        self.kwargs = kwargs
+
+    @classmethod
+    def from_data(cls, timestamp, sensor_key, data):
+        return cls(_data=data)
+
 
 StateAndVariance = namedtuple("StateAndVariance", ["state", "covariance"])
 
@@ -48,11 +59,16 @@ class ManagedFilter:
                 control=control,
             )
 
+            if sensor_reading._data is None:
+                sensor_reading._data = self._impl.make_reading(
+                    sensor_reading.sensor_key, **sensor_reading.kwargs
+                )
+
             (self.state, self.covariance) = self._impl.sensor_model(
                 state=self.state,
                 covariance=self.covariance,
                 sensor_key=sensor_reading.sensor_key,
-                sensor_reading=sensor_reading.data,
+                sensor_reading=sensor_reading._data,
             )
 
         _, state_and_variance = self._process_model(output_time, control)

--- a/py/formak/runtime.py
+++ b/py/formak/runtime.py
@@ -8,7 +8,7 @@ from math import floor
 from typing import List, Optional
 
 
-class StampedReading(object):
+class StampedReading:
     def __init__(self, timestamp, sensor_key, *, _data=None, **kwargs):
         self.timestamp = timestamp
         self.sensor_key = sensor_key

--- a/py/formak/templates/sensor_model.hpp
+++ b/py/formak/templates/sensor_model.hpp
@@ -54,7 +54,7 @@ _innovations[ReadingT::Identifier] = innovation;
 if constexpr (cpp::Config::innovation_filtering > 0.0) {
   if (formak::innovation_filtering::edit::removeInnovation(
           cpp::Config::innovation_filtering, ReadingT::size, innovation,
-          sensor_estimate_covariance)) {
+          S_inv)) {
     // Skip update
     return state;
   }

--- a/py/formak/templates/sensor_model.hpp
+++ b/py/formak/templates/sensor_model.hpp
@@ -53,8 +53,7 @@ _innovations[ReadingT::Identifier] = innovation;
 
 if constexpr (cpp::Config::innovation_filtering > 0.0) {
   if (formak::innovation_filtering::edit::removeInnovation(
-          cpp::Config::innovation_filtering, ReadingT::size, innovation,
-          S_inv)) {
+          cpp::Config::innovation_filtering, innovation, S_inv)) {
     // Skip update
     return state;
   }

--- a/py/formak/templates/sensor_model.hpp
+++ b/py/formak/templates/sensor_model.hpp
@@ -52,29 +52,9 @@ const typename ReadingT::InnovationT innovation =
 _innovations[ReadingT::Identifier] = innovation;
 
 if constexpr (cpp::Config::innovation_filtering > 0.0) {
-  constexpr double editing_threshold = cpp::Config::innovation_filtering;
-  constexpr size_t reading_size = ReadingT::size;
-  // y.T * C^{-1} * y - m > k * sqrt(2 * m)
-  // y.T * C^{-1} * y > k * sqrt(2 * m) + m
-  // Time Dependent > Consteval
-  std::cout << "innovation size: "
-            << (innovation.transpose() * innovation)(0, 0) << std::endl;
-  std::cout << "normalized innovation: "
-            << (innovation.transpose() * sensor_estimate_covariance.inverse() *
-                innovation)(0, 0)
-            << std::endl;
-  std::cout << innovation.transpose() << " * "
-            << sensor_estimate_covariance.inverse() << " * " << innovation
-            << " > " << editing_threshold << " * " << sqrt(2 * reading_size)
-            << " + " << reading_size << std::endl;
-  double normalizedInnovation =
-      (innovation.transpose() * sensor_estimate_covariance.inverse() *
-       innovation)(0, 0);
-  constexpr double innovationExpectation =
-      editing_threshold * std::sqrt(2 * reading_size) + reading_size;
-  std::cout << "normalized: " << normalizedInnovation
-            << " expected: " << innovationExpectation << std::endl;
-  if (normalizedInnovation > innovationExpectation) {
+  if (innovation_filtering::edit::removeInnovation(
+          cpp::Config::innovation_filtering, ReadingT::size, innovation,
+          sensor_estimate_covariance)) {
     // Skip update
     return state;
   }

--- a/py/formak/templates/sensor_model.hpp
+++ b/py/formak/templates/sensor_model.hpp
@@ -52,7 +52,7 @@ const typename ReadingT::InnovationT innovation =
 _innovations[ReadingT::Identifier] = innovation;
 
 if constexpr (cpp::Config::innovation_filtering > 0.0) {
-  if (innovation_filtering::edit::removeInnovation(
+  if (formak::innovation_filtering::edit::removeInnovation(
           cpp::Config::innovation_filtering, ReadingT::size, innovation,
           sensor_estimate_covariance)) {
     // Skip update

--- a/py/formak/ui.py
+++ b/py/formak/ui.py
@@ -4,8 +4,10 @@ from formak.exceptions import ModelDefinitionError
 from sympy import Matrix, Symbol, simplify, symbols
 from sympy.parsing.sympy_parser import parse_expr
 
+from formak.common import UiModelBase
 
-class Model:
+
+class Model(UiModelBase):
     def __init__(
         self,
         dt,

--- a/py/private/formak_gen.bzl
+++ b/py/private/formak_gen.bzl
@@ -57,6 +57,6 @@ def cc_formak_model(namespace, name, pymain, pysrcs, pydeps = None, python_versi
         srcs = [OUTPUT_SOURCE],
         hdrs = [OUTPUT_HEADER],
         strip_include_prefix = "generated",
-        deps = ["@eigen//:eigen"],
+        deps = ["@eigen//:eigen", "//cpp:innovation-filtering"],
         visibility = visibility,
     )

--- a/py/test/formak/ExtendedKalmanFilter_test.cpp
+++ b/py/test/formak/ExtendedKalmanFilter_test.cpp
@@ -190,10 +190,10 @@ TEST_P(CppModelFailureCasesSensor, RerunCases) {
               first_innovation.norm() == 0.0);
 }
 
-INSTANTIATE_TEST_SUITE_P(PreviousFailureCases, CppModelFailureCasesSensor,
-                         ::testing::Values(Options{0.0, 0.0},
-                                           Options{-538778789133922.0,
-                                                   -538778789133922.0}));
+INSTANTIATE_TEST_SUITE_P(
+    PreviousFailureCases, CppModelFailureCasesSensor,
+    ::testing::Values(Options{0.0, 0.0}, Options{-4.0, 0.0},
+                      Options{-538778789133922.0, -538778789133922.0}));
 
 }  // namespace ekf_sensor_property_test
 

--- a/py/test/formak/ExtendedKalmanFilter_test.py
+++ b/py/test/formak/ExtendedKalmanFilter_test.py
@@ -37,9 +37,9 @@ def test_EKF_process_property(state_x, state_y, control_a):
         config=config,
     )
 
-    control_vector = np.array([[control_a]])
-    covariance = np.eye(2)
-    state_vector = np.array([[state_x, state_y]]).transpose()
+    control_vector = ekf.Control(a=control_a)
+    covariance = ekf.Covariance(x=1, y=1)
+    state_vector = ekf.State(x=state_x, y=state_y)
 
     if not np.isfinite(state_vector).all() or not np.isfinite(control_vector).all():
         # reject infinite / NaN inputs
@@ -105,13 +105,13 @@ def test_EKF_sensor_property(x, y, a):
         state_model=ui_Model,
         process_noise={ui.Symbol("a"): 1.0},
         sensor_models={"simple": {ui.Symbol("x"): ui.Symbol("x")}},
-        sensor_noises={"simple": np.eye(1)},
+        sensor_noises={"simple": {ui.Symbol("x"): 1.0}},
         config=config,
     )
 
-    control_vector = np.array([[a]])
-    covariance = np.eye(2)
-    state_vector = np.array([[x, y]]).transpose()
+    control_vector = ekf.Control(a=a)
+    covariance = ekf.Covariance(x=1, y=1)
+    state_vector = ekf.State(x=x, y=y)
 
     if not np.isfinite(state_vector).all() or not np.isfinite(control_vector).all():
         # reject infinite / NaN inputs
@@ -121,7 +121,10 @@ def test_EKF_sensor_property(x, y, a):
         reject()
 
     next_state, next_cov = ekf.sensor_model(
-        "simple", state=state_vector, covariance=covariance, sensor_reading=np.eye(1)
+        "simple",
+        state=state_vector,
+        covariance=covariance,
+        sensor_reading=ekf.make_reading("simple", 1),
     )
     first_innovation = ekf.innovations["simple"]
 
@@ -150,7 +153,10 @@ def test_EKF_sensor_property(x, y, a):
         raise
 
     ekf.sensor_model(
-        "simple", state=next_state, covariance=next_cov, sensor_reading=np.eye(1)
+        "simple",
+        state=next_state,
+        covariance=next_cov,
+        sensor_reading=ekf.make_reading("simple", 1),
     )
     second_innovation = ekf.innovations["simple"]
 
@@ -180,13 +186,13 @@ def test_EKF_sensor_property_failing_example():
         state_model=ui_Model,
         process_noise={ui.Symbol("a"): 1.0},
         sensor_models={"simple": {ui.Symbol("x"): ui.Symbol("x")}},
-        sensor_noises={"simple": np.eye(1)},
+        sensor_noises={"simple": {ui.Symbol("x"): 1.0}},
         config=config,
     )
 
-    control_vector = np.array([[a]])
-    covariance = np.eye(2)
-    state_vector = np.array([[x, y]]).transpose()
+    control_vector = ekf.Control(a=a)
+    covariance = ekf.Covariance(x=1, y=1)
+    state_vector = ekf.State(x=x, y=y)
 
     if not np.isfinite(state_vector).all() or not np.isfinite(control_vector).all():
         # reject infinite inputs
@@ -196,7 +202,10 @@ def test_EKF_sensor_property_failing_example():
         reject()
 
     next_state, next_cov = ekf.sensor_model(
-        "simple", state=state_vector, covariance=covariance, sensor_reading=np.eye(1)
+        "simple",
+        state=state_vector,
+        covariance=covariance,
+        sensor_reading=ekf.make_reading("simple", 1),
     )
     first_innovation = ekf.innovations["simple"]
 
@@ -225,7 +234,10 @@ def test_EKF_sensor_property_failing_example():
         raise
 
     ekf.sensor_model(
-        "simple", state=next_state, covariance=next_cov, sensor_reading=np.eye(1)
+        "simple",
+        state=next_state,
+        covariance=next_cov,
+        sensor_reading=ekf.make_reading("simple", 1),
     )
     second_innovation = ekf.innovations["simple"]
 

--- a/py/test/formak/Model_test.py
+++ b/py/test/formak/Model_test.py
@@ -30,11 +30,16 @@ def test_Model_impl_property(x, y, a):
         config,
     )
 
-    control_vector = np.array([[a]])
-    state_vector = np.array([[x, y]]).transpose()
-    if not np.isfinite(state_vector).all() or not np.isfinite(control_vector).all():
+    control_vector = model.Control(a=a)
+    state_vector = model.State(x=x, y=y)
+    if (
+        not np.isfinite(state_vector.data).all()
+        or not np.isfinite(control_vector.data).all()
+    ):
         reject()
-    if (np.abs(state_vector) > 1e100).any() or (np.abs(control_vector) > 1e100).any():
+    if (np.abs(state_vector.data) > 1e100).any() or (
+        np.abs(control_vector.data) > 1e100
+    ).any():
         reject()
 
     next_state = model.model(dt=dt, state=state_vector, control_vector=control_vector)

--- a/py/test/unit/common_test.py
+++ b/py/test/unit/common_test.py
@@ -1,0 +1,36 @@
+import pytest
+
+from formak.common import named_vector
+
+
+def test_named_empty():
+    Empty = named_vector("Empty", [])
+
+    allowed = Empty()
+
+    with pytest.raises(TypeError):
+        disallowed = Empty(z=1.0)
+
+
+def test_named_short():
+    X = named_vector("X", ["x"])
+    print(X)
+    print(type(X))
+
+    allowed = X(x=6)
+    print(allowed)
+    print(type(allowed))
+
+    with pytest.raises(TypeError):
+        disallowed = X(z=1.0)
+
+
+def test_named_long():
+    XYZ = named_vector("XYZ", ["x", "y", "z"])
+
+    allowed = XYZ(x=6)
+    allowed = XYZ(y=6)
+    allowed = XYZ(y=6, z=5)
+
+    with pytest.raises(TypeError):
+        disallowed = XYZ(q=1.0)

--- a/py/test/unit/common_test.py
+++ b/py/test/unit/common_test.py
@@ -1,18 +1,20 @@
 import pytest
 
-from formak.common import named_vector
+from formak.common import named_covariance, named_vector
 
 
-def test_named_empty():
+def test_named_vector_empty():
     Empty = named_vector("Empty", [])
 
     allowed = Empty()
+
+    assert allowed.data.shape == (0, 1)
 
     with pytest.raises(TypeError):
         disallowed = Empty(z=1.0)
 
 
-def test_named_short():
+def test_named_vector_short():
     X = named_vector("X", ["x"])
     print(X)
     print(type(X))
@@ -20,17 +22,59 @@ def test_named_short():
     allowed = X(x=6)
     print(allowed)
     print(type(allowed))
+    assert allowed.data.shape == (1, 1)
 
     with pytest.raises(TypeError):
         disallowed = X(z=1.0)
 
 
-def test_named_long():
+def test_named_vector_long():
     XYZ = named_vector("XYZ", ["x", "y", "z"])
 
     allowed = XYZ(x=6)
     allowed = XYZ(y=6)
     allowed = XYZ(y=6, z=5)
+
+    assert allowed.data.shape == (3, 1)
+
+    with pytest.raises(TypeError):
+        disallowed = XYZ(q=1.0)
+
+
+def test_named_covariance_empty():
+    Empty = named_covariance("Empty", [])
+
+    allowed = Empty()
+
+    assert allowed.data.shape == (0, 0)
+
+    with pytest.raises(TypeError):
+        disallowed = Empty(z=1.0)
+
+
+def test_named_covariance_short():
+    X = named_covariance("X", ["x"])
+    print(X)
+    print(type(X))
+
+    allowed = X(x=6)
+    print(allowed)
+    print(type(allowed))
+
+    assert allowed.data.shape == (1, 1)
+
+    with pytest.raises(TypeError):
+        disallowed = X(z=1.0)
+
+
+def test_named_covariance_long():
+    XYZ = named_covariance("XYZ", ["x", "y", "z"])
+
+    allowed = XYZ(x=6)
+    allowed = XYZ(y=6)
+    allowed = XYZ(y=6, z=5)
+
+    assert allowed.data.shape == (3, 3)
 
     with pytest.raises(TypeError):
         disallowed = XYZ(q=1.0)

--- a/py/test/unit/cpp/ExtendedKalmanFilterWithCalibration_test.cpp
+++ b/py/test/unit/cpp/ExtendedKalmanFilterWithCalibration_test.cpp
@@ -36,23 +36,6 @@ INSTANTIATE_TEST_SUITE_P(StateTestCases, ProcessWithCalibrationTest,
                                                    .xEnd = 4.5}));
 }  // namespace process_with_calibration_test
 
-// ui_model = ui.Model(
-//     dt=dt,
-//     state=set([x]),
-//     control=set(),
-//     calibration=set([a, b]),
-//     state_model={x: x + a + b},
-// )
-//
-// cpp_implementation = cpp.compile_ekf(
-//     state_model=ui_model,
-//     process_noise={},
-//     sensor_models={"y": {y: x + b}},
-//     sensor_noises={"y": np.eye(1)},
-//     calibration_map={ui.Symbol("a"): 5.0, ui.Symbol("b"): 0.5},
-//     config={},
-// )
-
 namespace ekf_sensor_test {
 TEST(EKF, SensorY) {
   ExtendedKalmanFilter ekf;

--- a/py/test/unit/cpp/generator_ekf.py
+++ b/py/test/unit/cpp/generator_ekf.py
@@ -14,6 +14,7 @@ cpp_implementation = cpp.compile_ekf(
         "combined": {"reading2": ui.Symbol("x") + ui.Symbol("y")},
     },
     sensor_noises={"simple": {"reading1": 1}, "combined": {"reading2": 4.0}},
+    config={"innovation_filtering": None}
 )
 
 print("Wrote header at path {}".format(cpp_implementation.header_path))

--- a/py/test/unit/cpp/generator_ekf.py
+++ b/py/test/unit/cpp/generator_ekf.py
@@ -1,5 +1,3 @@
-import numpy as np
-
 from formak import cpp, ui
 
 cpp_implementation = cpp.compile_ekf(
@@ -15,7 +13,7 @@ cpp_implementation = cpp.compile_ekf(
         "simple": {"reading1": ui.Symbol("x")},
         "combined": {"reading2": ui.Symbol("x") + ui.Symbol("y")},
     },
-    sensor_noises={"simple": np.eye(1), "combined": np.eye(1) * 4.0},
+    sensor_noises={"simple": {"reading1": 1}, "combined": {"reading2": 4.0}},
 )
 
 print("Wrote header at path {}".format(cpp_implementation.header_path))

--- a/py/test/unit/cpp/generator_ekf.py
+++ b/py/test/unit/cpp/generator_ekf.py
@@ -14,7 +14,7 @@ cpp_implementation = cpp.compile_ekf(
         "combined": {"reading2": ui.Symbol("x") + ui.Symbol("y")},
     },
     sensor_noises={"simple": {"reading1": 1}, "combined": {"reading2": 4.0}},
-    config={"innovation_filtering": None}
+    config={"innovation_filtering": None},
 )
 
 print("Wrote header at path {}".format(cpp_implementation.header_path))

--- a/py/test/unit/cpp/generator_ekf_cse.py
+++ b/py/test/unit/cpp/generator_ekf_cse.py
@@ -1,5 +1,3 @@
-import numpy as np
-
 from formak import cpp, ui
 
 cpp_implementation = cpp.compile_ekf(
@@ -18,7 +16,7 @@ cpp_implementation = cpp.compile_ekf(
         "simple": {"reading1": ui.Symbol("x")},
         "combined": {"reading2": ui.Symbol("x") + ui.Symbol("y")},
     },
-    sensor_noises={"simple": np.eye(1), "combined": np.eye(1) * 4.0},
+    sensor_noises={"simple": {"reading1": 1.0}, "combined": {"reading2": 4.0}},
     config=cpp.Config(common_subexpression_elimination=True),
 )
 

--- a/py/test/unit/cpp/generator_ekf_no_cse.py
+++ b/py/test/unit/cpp/generator_ekf_no_cse.py
@@ -1,5 +1,3 @@
-import numpy as np
-
 from formak import cpp, ui
 
 cpp_implementation = cpp.compile_ekf(
@@ -18,7 +16,7 @@ cpp_implementation = cpp.compile_ekf(
         "simple": {"reading1": ui.Symbol("x")},
         "combined": {"reading2": ui.Symbol("x") + ui.Symbol("y")},
     },
-    sensor_noises={"simple": np.eye(1), "combined": np.eye(1) * 4.0},
+    sensor_noises={"simple": {"reading1": 1.0}, "combined": {"reading2": 4.0}},
     config=cpp.Config(common_subexpression_elimination=False),
 )
 

--- a/py/test/unit/cpp/generator_ekf_with_calibration.py
+++ b/py/test/unit/cpp/generator_ekf_with_calibration.py
@@ -1,5 +1,3 @@
-import numpy as np
-
 from formak import cpp, ui
 
 dt, a, b, x, y = ui.symbols(["dt", "a", "b", "x", "y"])
@@ -16,7 +14,7 @@ cpp_implementation = cpp.compile_ekf(
     state_model=ui_model,
     process_noise={},
     sensor_models={"y": {y: x + b}},
-    sensor_noises={"y": np.eye(1)},
+    sensor_noises={"y": {y: 1}},
     calibration_map={ui.Symbol("a"): 5.0, ui.Symbol("b"): 0.5},
     config={},
 )

--- a/py/test/unit/innovation_test.py
+++ b/py/test/unit/innovation_test.py
@@ -39,7 +39,7 @@ def test_constructor():
     calibration_map = {ui.Symbol("calibration_velocity"): 0.0}
     ekf = make_ekf(calibration_map)
 
-    innovation = np.zeros((1,1))
+    innovation = np.zeros((1, 1))
     S_inv = np.eye(1)
 
     assert not ekf.remove_innovation(innovation, S_inv)

--- a/py/test/unit/innovation_test.py
+++ b/py/test/unit/innovation_test.py
@@ -1,0 +1,55 @@
+import numpy as np
+
+from formak import python, ui
+
+
+def make_ekf(calibration_map):
+    dt = ui.Symbol("dt")
+
+    state = ui.Symbol("state")
+
+    control_velocity = ui.Symbol("control_velocity")
+    calibration_velocity = ui.Symbol("calibration_velocity")
+
+    state_model = {state: state + dt * (control_velocity + calibration_velocity)}
+
+    state_set = {state}
+    control_set = {control_velocity}
+
+    model = ui.Model(
+        dt=dt,
+        state=state_set,
+        control=control_set,
+        state_model=state_model,
+        calibration={calibration_velocity},
+    )
+
+    ekf = python.compile_ekf(
+        state_model=model,
+        process_noise={control_velocity: 1.0},
+        sensor_models={"simple": {state: state}},
+        sensor_noises={"simple": {state: 1e-9}},
+        calibration_map=calibration_map,
+        config={"innovation_filtering": 3.0},
+    )
+    return ekf
+
+
+def test_constructor():
+    calibration_map = {ui.Symbol("calibration_velocity"): 0.0}
+    ekf = make_ekf(calibration_map)
+
+    innovation = np.zeros((1,1))
+    S_inv = np.eye(1)
+
+    assert not ekf.remove_innovation(innovation, S_inv)
+
+    innovation = np.array([[4.0]])
+    S_inv = np.eye(1)
+
+    assert ekf.remove_innovation(innovation, S_inv)
+
+    innovation = np.array([[-4.0]])
+    S_inv = np.eye(1)
+
+    assert ekf.remove_innovation(innovation, S_inv)

--- a/py/test/unit/python/Model_test.py
+++ b/py/test/unit/python/Model_test.py
@@ -1,6 +1,5 @@
 import warnings
 
-import numpy as np
 from numpy.testing import assert_almost_equal
 
 from formak import python, ui
@@ -107,17 +106,17 @@ def test_Model_impl_no_control():
         config,
     )
 
-    state_vector = np.array([[0.0, 0.0]]).transpose()
-    assert (model.model(dt=dt, state=state_vector).transpose() == [0.0, 0.1]).all()
+    state_vector = model.State()
+    assert (model.model(dt=dt, state=state_vector).data.transpose() == [0.0, 0.1]).all()
 
-    state_vector = np.array([[0.0, 1.0]]).transpose()
-    assert (model.model(dt=dt, state=state_vector).transpose() == [0.0, 1.1]).all()
+    state_vector = model.State(y=1.0)
+    assert (model.model(dt=dt, state=state_vector).data.transpose() == [0.0, 1.1]).all()
 
-    state_vector = np.array([[1.0, 0.0]]).transpose()
-    assert (model.model(dt=dt, state=state_vector).transpose() == [0.0, 0.1]).all()
+    state_vector = model.State(x=1.0)
+    assert (model.model(dt=dt, state=state_vector).data.transpose() == [0.0, 0.1]).all()
 
-    state_vector = np.array([[1.0, 1.0]]).transpose()
-    assert (model.model(dt=dt, state=state_vector).transpose() == [1.0, 1.1]).all()
+    state_vector = model.State(x=1.0, y=1.0)
+    assert (model.model(dt=dt, state=state_vector).data.transpose() == [1.0, 1.1]).all()
 
 
 def test_Model_impl_control():
@@ -134,36 +133,36 @@ def test_Model_impl_control():
         config,
     )
 
-    control_vector = np.array([[0.2]])
+    control_vector = model.Control(a=0.2)
 
-    state_vector = np.array([[0.0, 0.0]]).transpose()
+    state_vector = model.State()
     assert_almost_equal(
         model.model(
             dt=dt, state=state_vector, control_vector=control_vector
-        ).transpose(),
+        ).data.transpose(),
         [[0.0, 0.02]],
     )
 
-    state_vector = np.array([[0.0, 1.0]]).transpose()
+    state_vector = model.State(y=1.0)
     assert_almost_equal(
         model.model(
             dt=dt, state=state_vector, control_vector=control_vector
-        ).transpose(),
+        ).data.transpose(),
         [[0.0, 1.02]],
     )
 
-    state_vector = np.array([[1.0, 0.0]]).transpose()
+    state_vector = model.State(x=1.0)
     assert_almost_equal(
         model.model(
             dt=dt, state=state_vector, control_vector=control_vector
-        ).transpose(),
+        ).data.transpose(),
         [[0.0, 0.02]],
     )
 
-    state_vector = np.array([[1.0, 1.0]]).transpose()
+    state_vector = model.State(x=1.0, y=1.0)
     assert_almost_equal(
         model.model(
             dt=dt, state=state_vector, control_vector=control_vector
-        ).transpose(),
+        ).data.transpose(),
         [[1.0, 1.02]],
     )

--- a/py/test/unit/python/calibration_test.py
+++ b/py/test/unit/python/calibration_test.py
@@ -1,5 +1,3 @@
-import numpy as np
-
 from formak import python, ui
 
 
@@ -24,16 +22,16 @@ def test_Model_creation_calibration():
 
     dt = 0.1
 
-    state_vector = np.array([[0.0]])
-    assert (model.model(dt=dt, state=state_vector).transpose() == [0.0]).all()
+    state_vector = model.State(x=0.0)
+    assert (model.model(dt=dt, state=state_vector).data.transpose() == [0.0]).all()
 
     model = python.compile(
         ui_model,
         calibration_map={ui.Symbol("a"): 5.0, ui.Symbol("b"): 0.5},
         config={},
     )
-    state_vector = np.array([[-1.0]])
-    assert (model.model(dt=dt, state=state_vector).transpose() == [4.5]).all()
+    state_vector = model.State(x=-1.0)
+    assert (model.model(dt=dt, state=state_vector).data.transpose() == [4.5]).all()
 
 
 def test_EKF_creation_calibration():
@@ -53,19 +51,19 @@ def test_EKF_creation_calibration():
         state_model=ui_model,
         process_noise={},
         sensor_models={y: {y: x + b}},
-        sensor_noises={y: np.eye(1)},
+        sensor_noises={y: {y: 1}},
         calibration_map={a: 0.0, b: 0.0},
         config={},
     )
 
     dt = 0.1
-    state_covariance = np.eye(1)
+    state_covariance = ekf.Covariance(x=1)
 
-    state_vector = np.array([[0.0]])
+    state_vector = ekf.State(x=0.0)
     assert (
         ekf.process_model(
             dt=dt, state=state_vector, covariance=state_covariance
-        ).state.transpose()
+        ).state.data.transpose()
         == [0.0]
     ).all()
 
@@ -73,14 +71,14 @@ def test_EKF_creation_calibration():
         ui_model,
         process_noise={},
         sensor_models={y: {y: x + b}},
-        sensor_noises={y: np.eye(1)},
+        sensor_noises={y: {y: 1}},
         calibration_map={a: 5.0, b: 0.5},
         config={},
     )
-    state_vector = np.array([[-1.0]])
+    state_vector = ekf.State(x=-1.0)
     assert (
         ekf.process_model(
             dt=dt, state=state_vector, covariance=state_covariance
-        ).state.transpose()
+        ).state.data.transpose()
         == [4.5]
     ).all()

--- a/py/test/unit/python/scikit_learn_fit_test.py
+++ b/py/test/unit/python/scikit_learn_fit_test.py
@@ -21,7 +21,7 @@ def test_fit():
     params = {
         "process_noise": {v: 1.0},
         "sensor_models": {"simple": {x: x}},
-        "sensor_noises": {"simple": np.eye(1)},
+        "sensor_noises": {"simple": {x: 1}},
     }
 
     model = python.compile_ekf(

--- a/py/test/unit/python/scikit_learn_fit_transform_test.py
+++ b/py/test/unit/python/scikit_learn_fit_transform_test.py
@@ -18,7 +18,7 @@ def test_fit_transform():
     params = {
         "process_noise": {v: 1.0},
         "sensor_models": {"simple": {x: x}},
-        "sensor_noises": {"simple": np.eye(1)},
+        "sensor_noises": {"simple": {x: 1}},
     }
 
     model = python.compile_ekf(

--- a/py/test/unit/python/scikit_learn_mahalanobis_test.py
+++ b/py/test/unit/python/scikit_learn_mahalanobis_test.py
@@ -18,7 +18,7 @@ def test_mahalanobis():
     params = {
         "process_noise": {v: 1.0},
         "sensor_models": {"simple": {x: x}},
-        "sensor_noises": {"simple": np.eye(1)},
+        "sensor_noises": {"simple": {x: 1}},
     }
 
     model = python.compile_ekf(

--- a/py/test/unit/python/scikit_learn_params_test.py
+++ b/py/test/unit/python/scikit_learn_params_test.py
@@ -23,7 +23,7 @@ def test_get_params():
     params = {
         "process_noise": {thrust: 1.0},
         "sensor_models": {"simple": {ui.Symbol("v"): ui.Symbol("v")}},
-        "sensor_noises": {"simple": np.eye(1)},
+        "sensor_noises": {"simple": {ui.Symbol("v"): 1}},
     }
 
     model = python.compile_ekf(
@@ -60,7 +60,7 @@ def test_set_params():
     params = {
         "process_noise": {thrust: 1.0},
         "sensor_models": {"simple": {ui.Symbol("v"): ui.Symbol("v")}},
-        "sensor_noises": {"simple": np.eye(1)},
+        "sensor_noises": {"simple": {ui.Symbol("v"): 1}},
     }
 
     model = python.compile_ekf(

--- a/py/test/unit/python/scikit_learn_score_test.py
+++ b/py/test/unit/python/scikit_learn_score_test.py
@@ -18,7 +18,7 @@ def test_score():
     params = {
         "process_noise": {v: 1.0},
         "sensor_models": {"simple": {x: x}},
-        "sensor_noises": {"simple": np.eye(1)},
+        "sensor_noises": {"simple": {x: 1}},
     }
 
     model = python.compile_ekf(
@@ -58,7 +58,7 @@ def test_score_two_sensor():
     params = {
         "process_noise": {ui.Symbol("a"): 1.0},
         "sensor_models": {"position": {x: x}, "velocity": {v: v}},
-        "sensor_noises": {"position": np.eye(1), "velocity": np.eye(1)},
+        "sensor_noises": {"position": {x: 1}, "velocity": {v: 1}},
     }
 
     model = python.compile_ekf(
@@ -100,7 +100,7 @@ def test_score_two_sensor_explained():
     params = {
         "process_noise": {ui.Symbol("a"): 1.0},
         "sensor_models": {"position": {x: x}, "velocity": {v: v}},
-        "sensor_noises": {"position": np.eye(1), "velocity": np.eye(1)},
+        "sensor_noises": {"position": {x: 1}, "velocity": {v: 1}},
     }
 
     model = python.compile_ekf(

--- a/py/test/unit/python/scikit_learn_transform_test.py
+++ b/py/test/unit/python/scikit_learn_transform_test.py
@@ -64,9 +64,15 @@ def test_transform_kalman_filter_args():
     innovations, states, covariances = model.transform(X, include_states=True)
 
     assert innovations.shape == (n_samples, n_features - len(control))
-    assert states.shape == (n_samples + 1, len(state), 1)
-    assert covariances.shape == (n_samples + 1, len(state), len(state))
+    assert states.shape == (n_samples + 1,)
+    assert isinstance(states[0], model.State)
+    assert covariances.shape == (n_samples + 1,)
+    assert isinstance(covariances[0], model.Covariance)
 
     assert not np.allclose(innovations, np.zeros_like(innovations))
-    assert not np.allclose(states, np.zeros_like(states))
-    assert not np.allclose(covariances, np.zeros_like(covariances))
+    assert not np.allclose(
+        [s.data for s in states], np.zeros((n_samples + 1, len(state), 1))
+    )
+    assert not np.allclose(
+        [c.data for c in covariances], np.zeros((n_samples + 1, len(state), len(state)))
+    )

--- a/py/test/unit/python/scikit_learn_transform_test.py
+++ b/py/test/unit/python/scikit_learn_transform_test.py
@@ -18,7 +18,7 @@ def test_transform():
     params = {
         "process_noise": {v: 1e-6},
         "sensor_models": {"simple": {x: x}},
-        "sensor_noises": {"simple": np.eye(1)},
+        "sensor_noises": {"simple": {x: 1}},
     }
 
     model = python.compile_ekf(
@@ -51,7 +51,7 @@ def test_transform_kalman_filter_args():
     params = {
         "process_noise": {v: 1.0},
         "sensor_models": {"simple": {x: x}},
-        "sensor_noises": {"simple": np.eye(1)},
+        "sensor_noises": {"simple": {x: 1}},
     }
 
     model = python.compile_ekf(

--- a/py/test/unit/runtime/ManagedFilter_no_calibration_test.py
+++ b/py/test/unit/runtime/ManagedFilter_no_calibration_test.py
@@ -161,9 +161,7 @@ def test_tick_one_reading(output_dt, reading_dt):
 
     control = ekf.Control(control_velocity=-1.0)
     reading_v = -3.0
-    reading1 = StampedReading(
-        start_time + reading_dt, "simple", ekf.make_reading("simple", state=reading_v)
-    )
+    reading1 = StampedReading(start_time + reading_dt, "simple", state=reading_v)
 
     state0p1 = mf.tick(start_time + output_dt, control=control, readings=[reading1])
 
@@ -215,10 +213,7 @@ def test_tick_multi_reading(output_dt, shuffle_order):
 
     control = ekf.Control(control_velocity=-1.0)
     reading_v = -3.0
-    readings = [
-        StampedReading(t, "simple", ekf.make_reading("simple", state=reading_v))
-        for t in options
-    ]
+    readings = [StampedReading(t, "simple", state=reading_v) for t in options]
 
     state0p1 = mf.tick(start_time + output_dt, control=control, readings=readings)
 

--- a/py/test/unit/runtime/ManagedFilter_no_calibration_test.py
+++ b/py/test/unit/runtime/ManagedFilter_no_calibration_test.py
@@ -71,6 +71,7 @@ def make_ekf():
         process_noise={control_velocity: 1.0},
         sensor_models={"simple": {state: state}},
         sensor_noises={"simple": {state: 1e-9}},
+        config={"innovation_filtering": None},
     )
     return ekf
 
@@ -104,16 +105,16 @@ def test_tick_no_readings(dt):
     print(state0p1.state)
     print("reading")
     print(state, dt, control.data[0, 0])
-    print(state + dt * control.data[0, 0])
+    print(state.data + dt * control.data[0, 0])
     print("diff")
-    print((state0p1.state) - (state + dt * control.data[0, 0]))
+    print((state0p1.state.data) - (state.data + dt * control.data[0, 0]))
     assert np.isclose(
         state0p1.state.data, state.data + dt * control.data[0, 0], atol=2.0e-14
     ).all()
     if dt != 0.0:
-        assert state0p1.covariance > covariance
+        assert state0p1.covariance.data > covariance.data
     else:
-        assert state0p1.covariance == covariance
+        assert state0p1.covariance.data == covariance.data
 
 
 @settings(deadline=None)
@@ -138,9 +139,9 @@ def test_tick_empty_readings(dt):
         state0p1.state.data, state.data + dt * control.data[0, 0], atol=2.0e-14
     ).all()
     if dt != 0.0:
-        assert state0p1.covariance > covariance
+        assert state0p1.covariance.data > covariance.data
     else:
-        assert state0p1.covariance == covariance
+        assert state0p1.covariance.data == covariance.data
 
 
 @settings(deadline=None)
@@ -169,7 +170,7 @@ def test_tick_one_reading(output_dt, reading_dt):
     dt = output_dt - reading_dt
 
     print("state")
-    print(state[0, 0])
+    print(state.data[0, 0])
     print("reading")
     print(reading_v)
     print("state0p1")
@@ -178,7 +179,7 @@ def test_tick_one_reading(output_dt, reading_dt):
     print(reading_v, control.data[0, 0], dt)
     print(reading_v + control.data[0, 0] * dt)
     print("diff")
-    print((state0p1.state) - (reading_v + control.data[0, 0] * dt))
+    print((state0p1.state.data) - (reading_v + control.data[0, 0] * dt))
     assert np.isclose(
         state0p1.state.data, reading_v + control.data[0, 0] * dt, atol=2.0e-8
     ).all()
@@ -221,4 +222,4 @@ def test_tick_multi_reading(output_dt, shuffle_order):
 
     state0p1 = mf.tick(start_time + output_dt, control=control, readings=readings)
 
-    assert (state != state0p1.state).any()
+    assert (state.data != state0p1.state.data).any()

--- a/py/test/unit/runtime/ManagedFilter_no_calibration_test.py
+++ b/py/test/unit/runtime/ManagedFilter_no_calibration_test.py
@@ -70,15 +70,15 @@ def make_ekf():
         state_model=model,
         process_noise={control_velocity: 1.0},
         sensor_models={"simple": {state: state}},
-        sensor_noises={"simple": np.eye(1) * 1e-9},
+        sensor_noises={"simple": {state: 1e-9}},
     )
     return ekf
 
 
 def test_constructor():
     ekf = make_ekf()
-    state = np.array([[4.0]])
-    covariance = np.array([[1.0]])
+    state = ekf.State(state=4.0)
+    covariance = ekf.Covariance(state=1.0)
     _mf = ManagedFilter(ekf=ekf, start_time=0.0, state=state, covariance=covariance)
 
 
@@ -86,9 +86,9 @@ def test_constructor():
 @given(sampled_from(samples_dt_sec()))
 def test_tick_no_readings(dt):
     start_time = 10.0
-    state = np.array([[4.0]])
-    covariance = np.array([[1.0]])
     ekf = make_ekf()
+    state = ekf.State(state=4.0)
+    covariance = ekf.Covariance(state=1.0)
 
     mf = ManagedFilter(
         ekf=ekf,
@@ -97,17 +97,19 @@ def test_tick_no_readings(dt):
         covariance=covariance,
     )
 
-    control = np.array([[-1.0]])
+    control = ekf.Control(control_velocity=-1.0)
     state0p1 = mf.tick(start_time + dt, control=control)
 
     print("state")
     print(state0p1.state)
     print("reading")
-    print(state, dt, control[0, 0])
-    print(state + dt * control[0, 0])
+    print(state, dt, control.data[0, 0])
+    print(state + dt * control.data[0, 0])
     print("diff")
-    print((state0p1.state) - (state + dt * control[0, 0]))
-    assert np.isclose(state0p1.state, state + dt * control[0, 0], atol=2.0e-14).all()
+    print((state0p1.state) - (state + dt * control.data[0, 0]))
+    assert np.isclose(
+        state0p1.state.data, state.data + dt * control.data[0, 0], atol=2.0e-14
+    ).all()
     if dt != 0.0:
         assert state0p1.covariance > covariance
     else:
@@ -118,9 +120,9 @@ def test_tick_no_readings(dt):
 @given(sampled_from(samples_dt_sec()))
 def test_tick_empty_readings(dt):
     start_time = 10.0
-    state = np.array([[4.0]])
-    covariance = np.array([[1.0]])
     ekf = make_ekf()
+    state = ekf.State(state=4.0)
+    covariance = ekf.Covariance(state=1.0)
 
     mf = ManagedFilter(
         ekf=ekf,
@@ -129,10 +131,12 @@ def test_tick_empty_readings(dt):
         covariance=covariance,
     )
 
-    control = np.array([[-1.0]])
+    control = ekf.Control(control_velocity=-1.0)
     state0p1 = mf.tick(start_time + dt, control=control, readings=[])
 
-    assert np.isclose(state0p1.state, state + dt * control[0, 0], atol=2.0e-14).all()
+    assert np.isclose(
+        state0p1.state.data, state.data + dt * control.data[0, 0], atol=2.0e-14
+    ).all()
     if dt != 0.0:
         assert state0p1.covariance > covariance
     else:
@@ -143,9 +147,9 @@ def test_tick_empty_readings(dt):
 @given(sampled_from(samples_dt_sec()), sampled_from(samples_dt_sec()))
 def test_tick_one_reading(output_dt, reading_dt):
     start_time = 10.0
-    state = np.array([[4.0]])
-    covariance = np.array([[1.0]])
     ekf = make_ekf()
+    state = ekf.State(state=4.0)
+    covariance = ekf.Covariance(state=1.0)
 
     mf = ManagedFilter(
         ekf=ekf,
@@ -154,10 +158,10 @@ def test_tick_one_reading(output_dt, reading_dt):
         covariance=covariance,
     )
 
-    control = np.array([[-1.0]])
+    control = ekf.Control(control_velocity=-1.0)
     reading_v = -3.0
     reading1 = StampedReading(
-        start_time + reading_dt, "simple", np.array([[reading_v]])
+        start_time + reading_dt, "simple", ekf.make_reading("simple", state=reading_v)
     )
 
     state0p1 = mf.tick(start_time + output_dt, control=control, readings=[reading1])
@@ -171,11 +175,13 @@ def test_tick_one_reading(output_dt, reading_dt):
     print("state0p1")
     print(state0p1.state)
     print("reading")
-    print(reading_v, control[0, 0], dt)
-    print(reading_v + control[0, 0] * dt)
+    print(reading_v, control.data[0, 0], dt)
+    print(reading_v + control.data[0, 0] * dt)
     print("diff")
-    print((state0p1.state) - (reading_v + control[0, 0] * dt))
-    assert np.isclose(state0p1.state, reading_v + control[0, 0] * dt, atol=2.0e-8).all()
+    print((state0p1.state) - (reading_v + control.data[0, 0] * dt))
+    assert np.isclose(
+        state0p1.state.data, reading_v + control.data[0, 0] * dt, atol=2.0e-8
+    ).all()
 
 
 @settings(deadline=None)
@@ -195,9 +201,9 @@ def test_tick_one_reading(output_dt, reading_dt):
 def test_tick_multi_reading(output_dt, shuffle_order):
     output_dt, options = parse_options(output_dt, shuffle_order)
     start_time = 10.0
-    state = np.array([[4.0]])
-    covariance = np.array([[1.0]])
     ekf = make_ekf()
+    state = ekf.State(state=4.0)
+    covariance = ekf.Covariance(state=1.0)
 
     mf = ManagedFilter(
         ekf=ekf,
@@ -206,9 +212,12 @@ def test_tick_multi_reading(output_dt, shuffle_order):
         covariance=covariance,
     )
 
-    control = np.array([[-1.0]])
+    control = ekf.Control(control_velocity=-1.0)
     reading_v = -3.0
-    readings = [StampedReading(t, "simple", np.array([[reading_v]])) for t in options]
+    readings = [
+        StampedReading(t, "simple", ekf.make_reading("simple", state=reading_v))
+        for t in options
+    ]
 
     state0p1 = mf.tick(start_time + output_dt, control=control, readings=readings)
 

--- a/py/test/unit/runtime/ManagedFilter_no_control_test.py
+++ b/py/test/unit/runtime/ManagedFilter_no_control_test.py
@@ -72,6 +72,7 @@ def make_ekf(calibration_map):
         sensor_models={"simple": {state: state}},
         sensor_noises={"simple": {state: 1e-9}},
         calibration_map=calibration_map,
+        config={"innovation_filtering": None},
     )
     return ekf
 
@@ -107,9 +108,9 @@ def test_tick_no_readings(dt):
     print("reading")
     print(state, dt)
     print("diff")
-    print((state0p1.state) - (state))
+    print((state0p1.state.data) - (state.data))
     assert np.isclose(state0p1.state.data, state.data, atol=2.0e-14).all()
-    assert state0p1.covariance == covariance
+    assert state0p1.covariance.data == covariance.data
 
 
 @settings(deadline=None)
@@ -131,7 +132,7 @@ def test_tick_empty_readings(dt):
     state0p1 = mf.tick(start_time + dt, readings=[])
 
     assert np.isclose(state0p1.state.data, state.data, atol=2.0e-14).all()
-    assert state0p1.covariance == covariance
+    assert state0p1.covariance.data == covariance.data
 
 
 @settings(deadline=None)
@@ -158,7 +159,7 @@ def test_tick_one_reading(output_dt, reading_dt):
     state0p1 = mf.tick(start_time + output_dt, readings=[reading1])
 
     print("state")
-    print(state[0, 0])
+    print(state.data[0, 0])
     print("reading")
     print(reading_v)
     print("state0p1")
@@ -166,7 +167,7 @@ def test_tick_one_reading(output_dt, reading_dt):
     print("reading")
     print(reading_v)
     print("diff")
-    print((state0p1.state) - (reading_v))
+    print((state0p1.state.data) - (reading_v))
     assert np.isclose(state0p1.state.data, reading_v, atol=2.0e-8).all()
 
 
@@ -207,4 +208,4 @@ def test_tick_multi_reading(output_dt, shuffle_order):
 
     state0p1 = mf.tick(start_time + output_dt, readings=readings)
 
-    assert (state != state0p1.state).any()
+    assert (state.data != state0p1.state.data).any()

--- a/py/test/unit/runtime/ManagedFilter_no_control_test.py
+++ b/py/test/unit/runtime/ManagedFilter_no_control_test.py
@@ -152,9 +152,7 @@ def test_tick_one_reading(output_dt, reading_dt):
     )
 
     reading_v = -3.0
-    reading1 = StampedReading(
-        start_time + reading_dt, "simple", ekf.make_reading("simple", state=reading_v)
-    )
+    reading1 = StampedReading(start_time + reading_dt, "simple", state=reading_v)
 
     state0p1 = mf.tick(start_time + output_dt, readings=[reading1])
 
@@ -201,10 +199,7 @@ def test_tick_multi_reading(output_dt, shuffle_order):
     )
 
     reading_v = -3.0
-    readings = [
-        StampedReading(t, "simple", ekf.make_reading("simple", state=reading_v))
-        for t in options
-    ]
+    readings = [StampedReading(t, "simple", state=reading_v) for t in options]
 
     state0p1 = mf.tick(start_time + output_dt, readings=readings)
 

--- a/py/test/unit/runtime/ManagedFilter_test.py
+++ b/py/test/unit/runtime/ManagedFilter_test.py
@@ -171,9 +171,7 @@ def test_tick_one_reading(output_dt, reading_dt):
 
     control = ekf.Control(control_velocity=-1.0)
     reading_v = -3.0
-    reading1 = StampedReading(
-        start_time + reading_dt, "simple", ekf.make_reading("simple", state=reading_v)
-    )
+    reading1 = StampedReading(start_time + reading_dt, "simple", state=reading_v)
 
     state0p1 = mf.tick(start_time + output_dt, control=control, readings=[reading1])
 
@@ -226,10 +224,7 @@ def test_tick_multi_reading(output_dt, shuffle_order):
 
     control = ekf.Control(control_velocity=-1.0)
     reading_v = -3.0
-    readings = [
-        StampedReading(t, "simple", ekf.make_reading("simple", state=reading_v))
-        for t in options
-    ]
+    readings = [StampedReading(t, "simple", state=reading_v) for t in options]
 
     state0p1 = mf.tick(start_time + output_dt, control=control, readings=readings)
 

--- a/requirements.in
+++ b/requirements.in
@@ -14,3 +14,5 @@ setuptools>=65.5.1
 ## numba support
 # enables support for color highlighting in backtraces/error messages
 colorama==0.4.5
+
+graphviz==0.20.1

--- a/requirements_lock.txt
+++ b/requirements_lock.txt
@@ -20,6 +20,10 @@ exceptiongroup==1.1.1 \
     # via
     #   hypothesis
     #   pytest
+graphviz==0.20.1 \
+    --hash=sha256:587c58a223b51611c0cf461132da386edd896a029524ca61a1462b880bf97977 \
+    --hash=sha256:8c58f14adaa3b947daf26c19bc1e98c4e0702cdc31cf99153e6f06904d492bf8
+    # via -r requirements.in
 hypothesis==6.47.5 \
     --hash=sha256:87049b781ee11ec1c7948565b889ab02e428a1e32d427ab4de8fdb3649242d06 \
     --hash=sha256:e0c1e253fc97e7ecdb9e2bbff2cf815d8739e0d1d3d093d67c3af5bb6a7211b0


### PR DESCRIPTION
## Overview


FormaK aims to combine symbolic modeling for fast, efficient system modelling with code generation to create performant code that is easy to use.

The Five Key Elements the library provides to achieve this user experience are:
1. Python Interface to define models
2. Python implementation of the model and supporting tooling
3. Integration to scikit-learn to leverage the model selection and parameter tuning functions
4. C++ and Python to C++ interoperability for performance
5. C++ interfaces to support a variety of model uses

This design focuses on "Integration to scikit-learn to leverage the model selection and parameter tuning functions". The end result will be updates to Python and C++ models, but the primary effort will be improving the scikit-learn tooling. The current implementation provides some of the math for the EKF (process update, sensor update); however, that leaves the models open
to spurious readings. In the current implementation, if a FormaK filter gets a reading that is almost infinite, say 1e300, the response of the filter will be proportional and the response will cause the EKF to diverge as one or more of the states jump to positive infinity. This creates a gap in the filter that violates one of the FormaK values: easy to use (perhaps in this case it's
helpful to think of this as easy to use *correctly*).

This problem is known as jump detection. As the filter considers a sensor update the filter measures the divergence of the reading from what the model expects and then can reject readings with a divergence that is too large to be acceptable.

How should the filter measure this divergence? The filter can use the measurement innovation $$\tilde{y} = y - h(x)$$ where y is the measurement, $h$ is the measurement model and $x$ is the current state estimate and $\tilde{y}$ is the resulting innovation. Given the innovation, the definition of too large can be calculated from the expected covariance: 
$$\tilde{y}^{T} C^{-1} \tilde{y} - m > k \sqrt{2m}$$ 
where $C$ is the expected covariance of the measurement, $m$ is the dimension of the measurement vector and $k$ is the editing threshold. If this inequality is true, then the measurement is "too large" and should be filtered (edited). [1]

[1] This approach to innovation filtering, referred to as editing in the text, is adapted from "Advanced Kalman Filtering, Least Squares and Modeling" by Bruce P. Gibbs (referred to as [1] or AKFLSM)

Innovations take advantage of the property that errors are white (normally distributed) when all models are correct and, when operating in steady state, most variation in the sensor reading is expected to come from the noise in the sensor instead of noise in the state. Intuitively, if the sensor is consistently providing low variance updates, the state should converge further based on that information until the noise in the state relative to the sensor is low.

By implementing innovation filtering, the filter will become much more robust to errors in the sensor, the model and the overall system. By hooking into values that are already calculated as part of the sensor update there should be minimal additional performance cost.
